### PR TITLE
Include more documentation in the readme

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -132,7 +132,7 @@ The API token can be either a user-scoped token for development found in the
 token found in the [“General” tab of the “Configuration”](https://app.waldo.com/applications/0/configurations/general)
 for your app.
 
-On developer machines the token can also be stored in a local profile `.waldo/profile.yml` and is automatically picked
+On developer machines the token can also be stored in a local profile `~/.waldo/profile.yml` and is automatically picked
 up, a script is provided in this package to fill it:
 
 ```sh

--- a/Readme.md
+++ b/Readme.md
@@ -465,7 +465,7 @@ await driver.screenshot('my-screenshot.png');
 Send a log line that will be visible in the Waldo Session Viewer
 
 - `message`: The message to log
-- `payload`: Additional data to log that will be visible when the log line is selected
+- `payload`: Additional data to log that will be visible when the log line is selected. Default to `{}`.
 - `level`: The log level, one of `debug`, `info`, `warn`, or `error`. Default to `info`.
 
 Example:

--- a/Readme.md
+++ b/Readme.md
@@ -8,37 +8,90 @@ A [WebdriverIO](https://webdriver.io/) service that provides better integration 
 This package provides:
 
 - Automatic configuration of Waldo as the webdriver endpoint.
-- A collectin of additional commands to ease mobile testing.
+- A collection of additional commands to ease mobile testing.
 - A TypeScript definition for the options and mobile-specific capabilities.
+
+## Requirements
+
+- Node.js version 18 or later
+- WebdriverIO version 8
+- A [Waldo][waldo] account: [sign up here][signup]
 
 ## Installation
 
+### Starting from a sample project
+
+The easiest way to get started with this package if you aren't already using WebDriverIO is to clone the
+[sample repository](https://github.com/waldoapp/waldo-programmatic-samples) and follow the instructions
+[directly in Waldo](https://app.waldo.com/applications/0/sessions?guide=wikipedia-programmatic) or in it's
+[readme](https://github.com/waldoapp/waldo-programmatic-samples/blob/main/README.md).
+
+### Starting from scratch
+
+Full instructions on how to install `WebdriverIO` can be found [here](https://webdriver.io/docs/gettingstarted), but the easiest way is to use the CLI:
+
+```sh
+npm init wdio@latest .
+```
+
+Here are the steps to follow for an optimal configuration with Waldo
+(The only steps listed are the one that affect Waldo usage, the rest of the configuration is up to you):
+
+- _What type of testing would you like to do?_<br />
+  **E2E Testing - of Web or Mobile Applications**
+- _Where is your automation backend located?_<br />
+  **On my local machine** (We'll switch to Waldo later)
+- _Which environment you would like to automate?_<br />
+  **Mobile - native, hybrid and mobile web apps, on Android or iOS**
+- _Which mobile environment you'ld like to automate?_<br />
+  **Android** (We won't use the package but it's required)
+- _Do you want to add a service to your test setup?_<br />
+  **Remove appium that was added by default**
+- _Continue with Appium setup using appium-installer?_<br />
+  **No**
+
+You'll get a project where you can remove the automatically added `appium-uiautomator2-driver`:
+
+```sh
+npm uninstall @wdio/appium-service appium-uiautomator2-driver
+```
+
+You can then proceed to [add Waldo to the project](#in-an-existing-webdriverio-project).
+
 ### In an existing WebDriverIO project
 
-The easiest way to install this package in an existing WebDriverIO project is to add the
-`@waldoapp/wdio-service` package as a `devDependency` in your `package.json`:
+To add this package in an existing WebDriverIO project is to add the `@waldoapp/wdio-service` package as a
+`devDependency` in your `package.json`:
 
 ```sh
 npm install @waldoapp/wdio-service --save-dev
 ```
 
-Instructions on how to install `WebdriverIO` can be found [here](https://webdriver.io/docs/gettingstarted).
+If you use TypeScript you'll also need to reference package for the types to be available, in `tsconfig.json` add `@waldoapp/wdio-service` to the types array:
+
+```json
+{
+  "compilerOptions": {
+    "types": [
+      "node",
+      // <snip>
+      "@waldoapp/wdio-service"
+    ]
+  }
+}
+```
+
+The next step would be to [configure the package](#configuration).
 
 ## Configuration
 
-To use the Waldo service, you need to provide a valid Waldo API token. This token can be specified by defining the `WALDO_API_TOKEN` environment variable, or by including the `key` option in your `wdio.conf.ts` file.
-
-The API token can be either a user-scoped token for development found in the
-[“Profile” tab of your Waldo account settings](https://app.waldo.com/settings/profile), or an application-scoped CI
-token found in the [“General” tab of the “Configuration”](https://app.waldo.com/applications/0/configurations/general)
-for your app.
+### Sample configuration file
 
 ```ts
 // wdio.conf.ts
-import '@waldoapp/wdio-service';
-
 export const config: WebdriverIO.Config = {
-  // This is done automatically if no key is provided,
+  // This is only for illustration purposes,
+  // this is done automatically if no key is provided,
   // the WALDO_API_TOKEN environment variable is used
   key: process.env.WALDO_API_TOKEN,
 
@@ -50,15 +103,118 @@ export const config: WebdriverIO.Config = {
       },
     ],
   ],
+
+  capabilities: [
+    {
+      platformName: 'Android',
+      // 'wiki' targets the sample Wikipedia application
+      // Replace with your application version ID
+      'appium:app': 'wiki',
+      'waldo:options': {
+        deviceName: 'Pixel 7',
+      },
+    },
+  ],
 };
 ```
 
-In order to run, you must upload your application binary to Waldo. A successful upload generates a build version ID of
-the form `appv-0123456789abcdef`. This version ID must then be provided in either the `versionId` option, or the
-`appium:app` capability field for Appium compatibility.
+### Authentication
+
+To use the Waldo service, you need to provide a valid Waldo API token.
+This token can be specified by defining the `WALDO_API_TOKEN` environment variable,
+or by including the `key` option in your `wdio.conf.ts` file.
+
+The API token can be either a user-scoped token for development found in the
+[“Profile” tab of your Waldo account settings](https://app.waldo.com/settings/profile), or an application-scoped CI
+token found in the [“General” tab of the “Configuration”](https://app.waldo.com/applications/0/configurations/general)
+for your app.
+
+On developer machines the token can also be stored in a local profile `.waldo/profile.yml` and is automatically picked
+up, a script is provided in this package to fill it:
+
+```sh
+npx waldo-auth [YourToken]
+```
+
+### Specifying the application binary/build to target
+
+In order to run, you must upload your application binary to Waldo.
+To do so, follow the instructions on the [Upload page](https://app.waldo.com/applications/0/builds/upload) while
+logged in or check [the documentation](https://docs.waldo.com/docs/upload-a-build).
+
+A successful upload generates a build version ID of the form `appv-0123456789abcdef` that can be copied via the
+`Copy build id` option in the 3 dots menu on the web and that is provided in the output when the CLI is used to
+upload.
+
+This version ID must then be provided in either the `versionId` option, or the `appium:app` capability.
 
 You do _not_ need to provide the `versionId` if instead you specify an existing running session with the `sessionId`
-option.
+option (The application version and device type are selected when the session is started).
+
+## Usage
+
+When you execute a script that uses Waldo Scripting, the script always uses a remote device session on a
+simulator/emulator running within the Waldo infrastructure.
+
+There are multiple ways to start a session depending on if you are developing a new script,
+running tests locally to verify a change or integrating with Continuous Integration (CI).
+
+### Interactive execution
+
+In this mode, your script interacts with an ongoing remote session that _remains alive_
+when execution reaches the end of the script.
+
+In order to run in this mode, you must first launch a session manually in Waldo by going to
+the [Live view](https://app.waldo.com/applications/0/sessions) and starting a session.
+
+As long as this session remains alive, you can execute your script against it.
+To do so you need to provide the session ID that can be obtained by using the `Use for script`
+button of the `Info` tab or from the URL (they are prefixed with `sess-`, such as `sess-1234567890abcdef`).
+
+```shell
+SESSION_ID=[SessionID] npm run wdio
+```
+
+_Note_: in this mode, it is not necessary to specify `VERSION_ID` since the remote session was already
+started with a specific app version.
+
+This mode is very useful for creating a new script or editing an existing one, since it allows you
+to quickly relaunch your app over and over without waiting for session initialization. In addition,
+this mode also allows you to perform some actions manually on the session in the browser, as well
+as use the tree inspector to determine the best way to locate an element.
+
+### Live execution
+
+In this mode, your script interacts with a freshly created remote session, where you can
+watch its execution in a browser in real time.
+
+For an example of running a script in live execution mode, try:
+
+```shell
+VERSION_ID=[VersionID] SHOW_SESSION=1 npm run wdio
+```
+
+This mode is very useful when you want to watch the current behavior of a script against a new
+application version or to reproduce an issue noticed in CI.
+
+### Background execution
+
+In this mode, your script interacts via Waldo Scripting with a freshly created remote
+session that is killed when execution reaches the end of the script.
+
+You do not have any visual feedback of what is happening; however, you can watch
+the replay of the execution at a later time.
+
+For an example of running a script in background execution mode, try:
+
+```shell
+VERSION_ID=[VersionID] npm run wdio
+```
+
+This is the most common mode of execution when you have a full suite of scripts to run in parallel
+(for instance from your CI).
+In such a case, you are usually only interested in accessing the session replay of a script that
+failed.
 
 ## Waldo service options
 

--- a/Readme.md
+++ b/Readme.md
@@ -16,7 +16,7 @@ This package provides:
 
 - Node.js version 18 or later
 - WebdriverIO version 8
-- A [Waldo][waldo] account: [sign up here][signup]
+- A Waldo account: [sign up here](https://app.waldo.com/register)
 
 ## Installation
 

--- a/Readme.md
+++ b/Readme.md
@@ -178,11 +178,13 @@ button of the `Info` tab or from the URL (they are prefixed with `sess-`, such a
 SESSION_ID=[SessionID] npm run wdio -- --spec [YourScript]
 ```
 
-> [!NOTE]
+> ℹ️ **Note**
+>
 > in this mode, it is not necessary to specify `VERSION_ID` since the remote session was already
 > started with a specific app version.
 
-> [!WARNING]
+> ⚠️️ **Warning**
+>
 > If you have multiple test files and don't specify a `--spec` option, all of them will be executed at the
 > same time, on the **SAME** device session.
 
@@ -202,7 +204,8 @@ It is enabled by setting the `SHOW_SESSION` environment variable to `1`:
 VERSION_ID=[VersionID] SHOW_SESSION=1 npm run wdio -- --spec [YourScript]
 ```
 
-> [!TIP]
+> 💡 **Tip**
+>
 > It's often better to always specify a single test file via the `--spec` option to avoid a
 > lot of browser tabs openning at the same time.
 

--- a/Readme.md
+++ b/Readme.md
@@ -126,6 +126,11 @@ export const config: WebdriverIO.Config = {
       },
     },
   ],
+
+  mochaOpts: {
+    // The default value is pretty low for mobile testing
+    timeout: 10 * 60 * 1000,
+  },
 };
 ```
 
@@ -363,3 +368,107 @@ If this option is not specified, the default device configured for the app in Wa
 
 Type: `string` <br/>
 Default: `undefined`
+
+## Additional commands
+
+In addition to configuring Waldo as a remote WebDriver endpoint this package also adds the following commands on the
+driver object:
+
+### tap
+
+Simulate a 'tap' gesture at the given coordinates.
+
+This is equivalent to the following actions: `pointerMove`, `pointerDown`, `pause`, `pointerUp`.
+
+Example:
+
+```ts
+await driver.tap(100, 100);
+```
+
+### tapCenterOfBox
+
+Simulate a 'tap' gesture at the center of the given bounding box.
+
+Example:
+
+```ts
+await driver.tap({ left: 100, y: 100, width: 200, height: 200 });
+```
+
+### getNodes
+
+Get all nodes in the Waldo tree that match the given predicate
+
+> ℹ️ **Note**
+>
+> This command is only available when using the Waldo automation via the
+> `'waldo:automationName': 'Waldo'` capability.
+
+Example:
+
+```ts
+const okButtons = await driver.getNodes(
+  // Find all nodes with a text that contains 'ok' case insensitive
+  (n) => n.text && n.text.match(/ok/i) !== null,
+);
+```
+
+### getWaldoTree
+
+Parse the current Waldo tree returned by `getPageSource()` and return it as a JSON object.
+
+> ℹ️ **Note**
+>
+> This command is only available when using the Waldo automation via the
+> `'waldo:automationName': 'Waldo'` capability.
+
+### swipeScreen
+
+Simulate a 'swipe' gesture in the given direction.
+
+The default movement without any options is a horizontal swipe from right (`95`) to left (`5`).
+
+This is equivalent to the following actions: `pointerMove`, `pointerDown`, `pause`, `pointerMove`, `pointerUp`.
+
+Parameters:
+
+- `direction`: The direction of the swipe, either `vertical` or `horizontal`. Default to `horizontal`.
+- `fromScreenPercent`: The starting point of the swipe as a percentage of the screen size. Default to `95`.
+- `toScreenPercent`: The ending point of the swipe as a percentage of the screen size. Default to `5`.
+
+Example:
+
+```ts
+await driver.swipeScreen('vertical', 90, 10);
+```
+
+### screenshot
+
+A simplified wrapper around the `saveScreenshot` command that saves the screenshot to a file in the
+`./screenshots/` directory, creating it if necessary.
+
+> ℹ️ **Note**
+>
+> If an absolute path is provided, this function is equivalent to calling `saveScreenshot`
+> directly.
+
+Example:
+
+```ts
+await driver.screenshot('my-screenshot.png');
+```
+
+### log
+
+Send a log line that will be visible in the Waldo Session Viewer
+
+- `message`: The message to log
+- `payload`: Additional data to log that will be visible when the log line is selected
+- `level`: The log level, one of `debug`, `info`, `warn`, or `error`. Default to `info`.
+
+Example:
+
+```ts
+await driver.log('Found logged in user', { name: detectedUserName }, 'debug');
+```

--- a/Readme.md
+++ b/Readme.md
@@ -375,6 +375,26 @@ Default: `undefined`
 In addition to configuring Waldo as a remote WebDriver endpoint this package also adds the following commands on the
 driver object:
 
+### waitForElement
+
+Wait until an element appears that has the `property` equal to `value` and returns it.
+
+An error will be thrown if the element can't be found after the timeout.
+
+Example:
+
+```ts
+const element = await driver.waitForElement('text', 'Hello, World!');
+```
+
+Parameters:
+
+- `property` Name of the property to match on elements
+- `value` Expected value of the property
+- `timeout` Maximum time in milliseconds to wait for the element to appear. Default to `5000`.
+- `delay` Interval in milliseconds between checks for the element. Default to `500`.
+- `waitForStability` If enabled wait for the element position to stabilize before tapping. Default to `false`.
+
 ### tap
 
 Simulate a 'tap' gesture at the given coordinates.
@@ -387,6 +407,65 @@ Example:
 await driver.tap(100, 100);
 ```
 
+### tapElement
+
+Wait until an element appears that has the `property` equal to `value` and then tap on it.
+
+An error will be thrown if the element can't be found after the timeout.
+
+Example:
+
+```ts
+await driver.tapElement('text', 'Skip');
+```
+
+- `property` Name of the property to match on elements
+- `value` Expected value of the property
+- `timeout` Maximum time in milliseconds to wait for the element to appear. Default to`5000`.
+- `delay` Interval in milliseconds between checks for the element. Default to `500`.
+- `waitForStability` If enabled wait for the element position to stabilize before tapping. Default to`false`.
+
+### tapElementWith
+
+Wait until an element appears that matches the predicate in the Waldo tree and then tap on it.
+
+An error will be thrown if the element can't be found after the retries.
+
+Example:
+
+```ts
+await driver.tapElementWith((n) => n.text === 'Skip');
+```
+
+> ℹ️ **Note**
+>
+> This command is only available when using the Waldo automation via the
+> `'waldo:automationName': 'Waldo'` capability.
+
+- `predicate` A function that returns `true` for the element to tap on
+- `position` Index of the element to match if there are multiple matches, or `'first'` or `'last'`. Default to `0`.
+- `retries` Maximum number of retries to find the element. Default to`3`.
+- `delay` Interval in milliseconds between retries. Default to`500`.
+
+### typeInElement
+
+Wait until an element appears that has the `property` equal to `value` and then type `text` in it.
+
+An error will be thrown if the element can't be found after the timeout.
+
+Example:
+
+```ts
+await driver.typeInElement('placeholder', 'email address', 'test@example.com');
+```
+
+- `property` Name of the property to match on elements
+- `value` Expected value of the property
+- `text` The text to type in the element
+- `timeout` Maximum time in milliseconds to wait for the element to appear. Default to`5000`.
+- `delay` Interval in milliseconds between checks for the element. Default to`500`.
+- `waitForStability` If enabled wait for the element position to stabilize before tapping. Default to`false`.
+
 ### tapCenterOfBox
 
 Simulate a 'tap' gesture at the center of the given bounding box.
@@ -394,7 +473,8 @@ Simulate a 'tap' gesture at the center of the given bounding box.
 Example:
 
 ```ts
-await driver.tap({ left: 100, y: 100, width: 200, height: 200 });
+const box = await driver.getNodes((n) => n.text === 'Skip')[0];
+await driver.tapCenterOfBox(box);
 ```
 
 ### getNodes
@@ -432,17 +512,18 @@ The default movement without any options is a horizontal swipe from right (`95`)
 
 This is equivalent to the following actions: `pointerMove`, `pointerDown`, `pause`, `pointerMove`, `pointerUp`.
 
+Example:
+
+```ts
+// Swipe from top to bottom
+await driver.swipeScreen('vertical', 10, 90);
+```
+
 Parameters:
 
 - `direction`: The direction of the swipe, either `vertical` or `horizontal`. Default to `horizontal`.
 - `fromScreenPercent`: The starting point of the swipe as a percentage of the screen size. Default to `95`.
 - `toScreenPercent`: The ending point of the swipe as a percentage of the screen size. Default to `5`.
-
-Example:
-
-```ts
-await driver.swipeScreen('vertical', 90, 10);
-```
 
 ### screenshot
 
@@ -457,19 +538,22 @@ A simplified wrapper around the `saveScreenshot` command that saves the screensh
 Example:
 
 ```ts
-await driver.screenshot('my-screenshot.png');
+// Final path will be ./screenshots/screenshot.png
+await driver.screenshot('screenshot.png');
 ```
 
 ### log
 
 Send a log line that will be visible in the Waldo Session Viewer
 
-- `message`: The message to log
-- `payload`: Additional data to log that will be visible when the log line is selected. Default to `{}`.
-- `level`: The log level, one of `debug`, `info`, `warn`, or `error`. Default to `info`.
-
 Example:
 
 ```ts
 await driver.log('Found logged in user', { name: detectedUserName }, 'debug');
 ```
+
+Parameters:
+
+- `message`: The message to log
+- `payload`: Additional data to log that will be visible when the log line is selected. Default to `{}`.
+- `level`: The log level, one of `debug`, `info`, `warn`, or `error`. Default to `info`.

--- a/Readme.md
+++ b/Readme.md
@@ -72,15 +72,15 @@ npm install @waldoapp/wdio-service --save-dev
 If you use TypeScript you'll also need to reference package for the types to be available,
 in `tsconfig.json` add `@waldoapp/wdio-service` to the types array:
 
-```json
+```js
 {
-  "compilerOptions": {
-    "types": [
-      "node",
+  compilerOptions: {
+    types: [
+      'node',
       // <snip>
-      "@waldoapp/wdio-service"
-    ]
-  }
+      '@waldoapp/wdio-service',
+    ],
+  },
 }
 ```
 

--- a/Readme.md
+++ b/Readme.md
@@ -294,8 +294,8 @@ Most of the service options can also be specified in the capabilities object for
 capabilities: [
   {
     platformName: 'Android',
-    deviceName: 'Pixel 3a',
     'waldo:options': {
+      deviceName: 'Pixel 3a',
       showSession: true,
     },
   },

--- a/Readme.md
+++ b/Readme.md
@@ -160,7 +160,7 @@ When you execute a script that uses Waldo Scripting, the script always uses a re
 simulator/emulator running within the Waldo infrastructure.
 
 There are multiple ways to start a session depending on if you are developing a new script,
-running tests locally to verify a change or integrating with Continuous Integration (CI).
+running tests locally to verify a change or running the test during Continuous Integration (CI).
 
 ### Interactive execution
 
@@ -175,11 +175,16 @@ To do so you need to provide the session ID that can be obtained by using the `U
 button of the `Info` tab or from the URL (they are prefixed with `sess-`, such as `sess-1234567890abcdef`).
 
 ```shell
-SESSION_ID=[SessionID] npm run wdio
+SESSION_ID=[SessionID] npm run wdio -- --spec [YourScript]
 ```
 
-_Note_: in this mode, it is not necessary to specify `VERSION_ID` since the remote session was already
-started with a specific app version.
+> [!NOTE]
+> in this mode, it is not necessary to specify `VERSION_ID` since the remote session was already
+> started with a specific app version.
+
+> [!WARNING]
+> If you have multiple test files and don't specify a `--spec` option, all of them will be executed at the
+> same time, on the **SAME** device session.
 
 This mode is very useful for creating a new script or editing an existing one, since it allows you
 to quickly relaunch your app over and over without waiting for session initialization. In addition,
@@ -191,11 +196,15 @@ as use the tree inspector to determine the best way to locate an element.
 In this mode, your script interacts with a freshly created remote session, where you can
 watch its execution in a browser in real time.
 
-For an example of running a script in live execution mode, try:
+It is enabled by setting the `SHOW_SESSION` environment variable to `1`:
 
 ```shell
-VERSION_ID=[VersionID] SHOW_SESSION=1 npm run wdio
+VERSION_ID=[VersionID] SHOW_SESSION=1 npm run wdio -- --spec [YourScript]
 ```
+
+> [!TIP]
+> It's often better to always specify a single test file via the `--spec` option to avoid a
+> lot of browser tabs openning at the same time.
 
 This mode is very useful when you want to watch the current behavior of a script against a new
 application version or to reproduce an issue noticed in CI.
@@ -208,7 +217,7 @@ session that is killed when execution reaches the end of the script.
 You do not have any visual feedback of what is happening; however, you can watch
 the replay of the execution at a later time.
 
-For an example of running a script in background execution mode, try:
+It is the default mode and simply needs a version ID to target:
 
 ```shell
 VERSION_ID=[VersionID] npm run wdio

--- a/Readme.md
+++ b/Readme.md
@@ -19,6 +19,7 @@ Table of contents:
 - [Configuration](#configuration)
 - [Usage](#usage)
 - [Waldo service options](#waldo-service-options)
+- [Additional commands](#additional-commands)
 
 ## Requirements
 

--- a/Readme.md
+++ b/Readme.md
@@ -12,6 +12,14 @@ This package provides:
 - A collection of additional commands to ease mobile testing.
 - A TypeScript definition for the options and mobile-specific capabilities.
 
+Table of contents:
+
+- [Requirements](#requirements)
+- [Installation](#installation)
+- [Configuration](#configuration)
+- [Usage](#usage)
+- [Waldo service options](#waldo-service-options)
+
 ## Requirements
 
 - Node.js version 18 or later

--- a/Readme.md
+++ b/Readme.md
@@ -3,7 +3,8 @@
 [![NPM](https://img.shields.io/npm/v/%40waldoapp%2Fwdio-service)](https://www.npmjs.com/package/@waldoapp/wdio-service)
 [![CI](https://github.com/waldoapp/wdio-service/actions/workflows/build.yaml/badge.svg)](https://github.com/waldoapp/wdio-service/actions/workflows/build.yaml)
 
-A [WebdriverIO](https://webdriver.io/) service that provides better integration with [Waldo](https://www.waldo.com/scripting).
+A [WebdriverIO](https://webdriver.io/) service that provides better integration with
+[Waldo](https://www.waldo.com/scripting).
 
 This package provides:
 
@@ -28,7 +29,8 @@ The easiest way to get started with this package if you aren't already using Web
 
 ### Starting from scratch
 
-Full instructions on how to install `WebdriverIO` can be found [here](https://webdriver.io/docs/gettingstarted), but the easiest way is to use the CLI:
+Full instructions on how to install `WebdriverIO` can be found [here](https://webdriver.io/docs/gettingstarted),
+but the easiest way is to use the CLI:
 
 ```sh
 npm init wdio@latest .
@@ -67,7 +69,8 @@ To add this package in an existing WebDriverIO project is to add the `@waldoapp/
 npm install @waldoapp/wdio-service --save-dev
 ```
 
-If you use TypeScript you'll also need to reference package for the types to be available, in `tsconfig.json` add `@waldoapp/wdio-service` to the types array:
+If you use TypeScript you'll also need to reference package for the types to be available,
+in `tsconfig.json` add `@waldoapp/wdio-service` to the types array:
 
 ```json
 {
@@ -251,7 +254,8 @@ Default: `true`
 
 ### sessionId
 
-The ID of an existing Waldo session (created via `Sessions > Live > Start session`) to connect to. This is useful for interactive development.
+The ID of an existing Waldo session (created via `Sessions > Live > Start session`) to connect to.
+This is useful for interactive development.
 
 The session ID can also be specified with the `WALDO_SESSION_ID` (or `SESSION_ID`) environment variable.
 
@@ -296,7 +300,9 @@ this is the equivalent of providing `UiAutomator2`, `UiAutomator2` or `Appium` a
 This makes it easy to port existing Appium scripts to Waldo but is based mainly on the accessibility view of the
 application.
 
-The `Waldo` automation name can also be used to enable same mode that is used by Waldo Automate. In this mode the tree returned is typically _more complete_ as it unifies native elements, Web views, React Native, and Flutter elements.
+The `Waldo` automation name can also be used to enable same mode that is used by Waldo Automate.
+In this mode the tree returned is typically _more complete_ as it unifies native elements, Web views, React Native,
+and Flutter elements.
 
 The `Waldo` automation name is required to use some of the additional commands added by this service like
 `getWaldoTree`, `getNodes` and `tapElementWith`.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@waldoapp/wdio-service",
-    "version": "0.2.1",
+    "version": "0.2.2-beta.1",
     "description": "Webdriver.io service for Waldo",
     "homepage": "https://www.waldo.com/scripting",
     "bugs": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@waldoapp/wdio-service",
-    "version": "0.2.2-beta.1",
+    "version": "0.2.2",
     "description": "Webdriver.io service for Waldo",
     "homepage": "https://www.waldo.com/scripting",
     "bugs": {

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -5,7 +5,7 @@ import process from 'process';
 import { command } from 'webdriver';
 import logger from '@wdio/logger';
 
-import { BoundingBox, SwipeDirection } from './types.js';
+import { BoundingBoxLike, SwipeDirection } from './types.js';
 import {
     tapElement,
     tapElementWith,
@@ -17,6 +17,7 @@ import {
     logEvent,
     findInTree,
     getWaldoTree,
+    resolveBoundingBox,
 } from './utils.js';
 import { WaldoTreeElement } from './tree-types.js';
 
@@ -134,8 +135,8 @@ export function addDriverCommands(driver: WebdriverIO.Browser) {
 
     driver.addCommand(
         'tapCenterOfBox',
-        async function commandFn(this: WebdriverIO.Browser, box: BoundingBox) {
-            return tapCenterOfBox(this, box);
+        async function commandFn(this: WebdriverIO.Browser, box: BoundingBoxLike) {
+            return tapCenterOfBox(this, resolveBoundingBox(box));
         },
     );
 

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -34,20 +34,6 @@ export function addDriverCommands(driver: WebdriverIO.Browser) {
         }),
     );
 
-    driver.addCommand(
-        'tapElement',
-        async function commandFn(
-            this: WebdriverIO.Browser,
-            property: string,
-            value: string,
-            timeout: number = 5000,
-            delay: number = 500,
-            waitForStability: boolean = false,
-        ) {
-            return tapElement(this, property, value, timeout, delay, waitForStability);
-        },
-    );
-
     // Thin wrapper around saveScreenshot to ensure that the destination directory always exists
     driver.addCommand(
         'screenshot',

--- a/src/service.ts
+++ b/src/service.ts
@@ -66,7 +66,15 @@ export class WaldoWdioService implements Services.ServiceInstance {
     }
 
     afterSession() {
+        if (!driver.capabilities) {
+            return;
+        }
+
         const { replayUrl } = driver.capabilities as WaldoRemoteCapability;
+        if (!replayUrl) {
+            return;
+        }
+
         log.info(`Waldo Session link: ${replayUrl}`);
     }
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -244,7 +244,10 @@ export type WaldoBrowser = {
      * Example:
      *
      * ```ts
-     * const nodes = await driver.getNodes((n) => n.text === 'Skip');
+     * const okButtons = await driver.getNodes(
+     *   // Find all nodes with a text that contains 'ok' case insensitive
+     *   (n) => n.text && n.text.match(/ok/i) !== null,
+     * );
      * ```
      *
      * **Note**: This command is only available when using the Waldo automation via the

--- a/src/types.ts
+++ b/src/types.ts
@@ -106,6 +106,65 @@ export type BoundingBoxLike = BoundingBox | Pick<WaldoTreeElement, 'x' | 'y' | '
 
 export type WaldoBrowser = {
     resetApp(): Promise<void>;
+
+    /**
+     * Wait until an element appears that has the `property` equal to `value` and returns it.
+     *
+     * An error will be thrown if the element can't be found after the timeout.
+     *
+     * Example:
+     *
+     * ```ts
+     * const element = await driver.waitForElement('text', 'Hello, World!');
+     * ```
+     *
+     * @param property Name of the property to match on elements
+     * @param value Expected value of the property
+     * @param timeout Maximum time in milliseconds to wait for the element to appear. Default to `5000`.
+     * @param delay Interval in milliseconds between checks for the element. Default to `500`.
+     * @param waitForStability If enabled wait for the element position to stabilize before tapping. Default to `false`.
+     */
+    waitForElement(
+        property: string,
+        value: string,
+        timeout?: number,
+        delay?: number,
+        waitForStability?: boolean,
+    ): Promise<AppiumElement>;
+
+    /**
+     * Simulate a 'tap' gesture at the given coordinates.
+     *
+     * This is equivalent to the following actions: `pointerMove`, `pointerDown`, `pause`, `pointerUp`.
+     *
+     * Example:
+     *
+     * ```ts
+     * await driver.tap(100, 200);
+     * ```
+     *
+     * @param x The x-coordinate of the tap
+     * @param y The y-coordinate of the tap
+     */
+    tap(x: number, y: number): Promise<void>;
+
+    /**
+     * Wait until an element appears that has the `property` equal to `value` and then tap on it.
+     *
+     * An error will be thrown if the element can't be found after the timeout.
+     *
+     * Example:
+     *
+     * ```ts
+     * await driver.tapElement('text', 'Skip');
+     * ```
+     *
+     * @param property Name of the property to match on elements
+     * @param value Expected value of the property
+     * @param timeout Maximum time in milliseconds to wait for the element to appear. Default to`5000`.
+     * @param delay Interval in milliseconds between checks for the element. Default to `500`.
+     * @param waitForStability If enabled wait for the element position to stabilize before tapping. Default to`false`.
+     */
     tapElement(
         property: string,
         value: string,
@@ -113,12 +172,51 @@ export type WaldoBrowser = {
         delay?: number,
         waitForStability?: boolean,
     ): Promise<void>;
+
+    /**
+     * Wait until an element appears that matches the predicate in the Waldo tree and then tap on it.
+     *
+     * An error will be thrown if the element can't be found after the retries.
+     *
+     * Example:
+     *
+     * ```ts
+     * await driver.tapElementWith((n) => n.text === 'Skip');
+     * ```
+     *
+     * **Note**: This command is only available when using the Waldo automation via the
+     * `'waldo:automationName': 'Waldo'` capability.
+     *
+     * @param predicate A function that returns `true` for the element to tap on
+     * @param position Index of the element to match if there are multiple matches, or `'first'` or `'last'`. Default to `0`.
+     * @param retries Maximum number of retries to find the element. Default to`3`.
+     * @param delay Interval in milliseconds between retries. Default to`500`.
+     */
     tapElementWith(
         predicate: (n: WaldoTreeElement) => boolean,
         position?: number | 'first' | 'last',
         retries?: number,
         delay?: number,
     ): Promise<void>;
+
+    /**
+     * Wait until an element appears that has the `property` equal to `value` and then type `text` in it.
+     *
+     * An error will be thrown if the element can't be found after the timeout.
+     *
+     * Example:
+     *
+     * ```ts
+     * await driver.typeInElement('placeholder', 'email address', 'test@example.com');
+     * ```
+     *
+     * @param property Name of the property to match on elements
+     * @param value Expected value of the property
+     * @param text The text to type in the element
+     * @param timeout Maximum time in milliseconds to wait for the element to appear. Default to`5000`.
+     * @param delay Interval in milliseconds between checks for the element. Default to`500`.
+     * @param waitForStability If enabled wait for the element position to stabilize before tapping. Default to`false`.
+     */
     typeInElement(
         property: string,
         value: string,
@@ -129,29 +227,25 @@ export type WaldoBrowser = {
     ): Promise<void>;
 
     /**
-     * Simulate a 'tap' gesture at the given coordinates.
-     *
-     * This is equivalent to the following actions: `pointerMove`, `pointerDown`, `pause`, `pointerUp`.
-     *
-     * @param x The x-coordinate of the tap
-     * @param y The y-coordinate of the tap
-     */
-    tap(x: number, y: number): Promise<void>;
-    waitForElement(
-        property: string,
-        value: string,
-        timeout?: number,
-        delay?: number,
-        waitForStability?: boolean,
-    ): Promise<AppiumElement>;
-
-    /**
      * Simulate a 'tap' gesture at the center of the given bounding box.
+     *
+     * Example:
+     *
+     * ```ts
+     * const box = await driver.getNodes((n) => n.text === 'Skip')[0];
+     * await driver.tapCenterOfBox(box);
+     * ```
      */
     tapCenterOfBox(box: BoundingBoxLike): Promise<void>;
 
     /**
      * Get all nodes in the Waldo tree that match the given predicate.
+     *
+     * Example:
+     *
+     * ```ts
+     * const nodes = await driver.getNodes((n) => n.text === 'Skip');
+     * ```
      *
      * **Note**: This command is only available when using the Waldo automation via the
      * `'waldo:automationName': 'Waldo'` capability.
@@ -173,6 +267,13 @@ export type WaldoBrowser = {
      *
      * This is equivalent to the following actions: `pointerMove`, `pointerDown`, `pause`, `pointerMove`, `pointerUp`.
      *
+     * Example:
+     *
+     * ```ts
+     * // Swipe from top to bottom
+     * await driver.swipeScreen('vertical', 10, 90);
+     * ```
+     *
      * @param direction The direction of the swipe, either `vertical` or `horizontal`. Default to `horizontal`.
      * @param fromScreenPercent The starting point of the swipe as a percentage of the screen size. Default to `95`.
      * @param toScreenPercent The ending point of the swipe as a percentage of the screen size. Default to `5`.
@@ -190,12 +291,25 @@ export type WaldoBrowser = {
      * **Note**: If an absolute path is provided, this function is equivalent to calling `saveScreenshot`
      * directly.
      *
+     * Example:
+     *
+     * ```ts
+     * // Final path will be ./screenshots/screenshot.png
+     * await driver.screenshot('screenshot.png');
+     * ```
+     *
      * @param path The path to save the screenshot to
      */
     screenshot(path: string): Promise<void>;
 
     /**
      * Send a log line that will be visible in the Waldo Session Viewer
+     *
+     * Example:
+     *
+     * ```ts
+     * await driver.log('Found logged in user', { name: detectedUserName }, 'debug');
+     * ```
      *
      * @param message The message to log
      * @param payload Additional data to log that will be visible when the log line is selected

--- a/src/types.ts
+++ b/src/types.ts
@@ -102,6 +102,8 @@ export type WaldoServiceOptions = WaldoSharedOptions & {
 
 export type BoundingBox = { width: number; height: number; top: number; left: number };
 
+export type BoundingBoxLike = BoundingBox | Pick<WaldoTreeElement, 'x' | 'y' | 'width' | 'height'>;
+
 export type WaldoBrowser = {
     resetApp(): Promise<void>;
     tapElement(
@@ -146,7 +148,7 @@ export type WaldoBrowser = {
     /**
      * Simulate a 'tap' gesture at the center of the given bounding box.
      */
-    tapCenterOfBox(box: BoundingBox): Promise<void>;
+    tapCenterOfBox(box: BoundingBoxLike): Promise<void>;
 
     /**
      * Get all nodes in the Waldo tree that match the given predicate.

--- a/src/types.ts
+++ b/src/types.ts
@@ -130,6 +130,9 @@ export type WaldoBrowser = {
      * Simulate a 'tap' gesture at the given coordinates.
      *
      * This is equivalent to the following actions: `pointerMove`, `pointerDown`, `pause`, `pointerUp`.
+     *
+     * @param x The x-coordinate of the tap
+     * @param y The y-coordinate of the tap
      */
     tap(x: number, y: number): Promise<void>;
     waitForElement(

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -3,7 +3,13 @@ import axios, { AxiosError } from 'axios';
 import logger from '@wdio/logger';
 
 import { getRemoteBaseUrl, getWdUrl } from './urls.js';
-import type { AppiumElement, BoundingBox, SessionInfo, SwipeDirection } from './types.js';
+import type {
+    AppiumElement,
+    BoundingBox,
+    BoundingBoxLike,
+    SessionInfo,
+    SwipeDirection,
+} from './types.js';
 import type { WaldoTree, WaldoTreeElement } from './tree-types.js';
 import { parseXmlAsWaldoTree } from './tree-parser.js';
 
@@ -50,6 +56,19 @@ export async function waitForSessionReady(driver: WebdriverIO.Browser) {
         throw new Error(`Session is in bad state ${sessionInfo.status}`);
     }
     log.info('Waldo session is ready');
+}
+
+export function resolveBoundingBox(box: BoundingBoxLike): BoundingBox {
+    if ('top' in box) {
+        return box;
+    } else {
+        return {
+            top: box.y,
+            left: box.x,
+            width: box.width,
+            height: box.height,
+        };
+    }
 }
 
 export async function logEvent(


### PR DESCRIPTION
Include more documentation in the readme and in the doc-comments.

* Document most of our custom commands, both in the code and in the readme. Including examples.
* Include full installation instructions, including how to use it from scratch
* Explain in the readme the different usage patterns (Interactive, CI) and how to use them with this library.