### PR TITLE
fix waitForElement not waiting enough

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,3 +1,19 @@
+## Version 0.2.3
+
+- Fix `waitForElement` to handle more `findElement` return values
+- Remove dependency on `lodash`
+
+## Version 0.2.2
+
+- Include more documentation in the readme
+
+## Version 0.2.1
+
+- Depend on `sax` at `^1.0.0` instead of `^1.4.1`
+- Fix error when importing `sax` at runtime
+- Add types to commands returning waldo tree elements
+- Move `webdriverio` to a peerDependency
+
 ## Version 0.2.0
 
 - Add `waldo:automationName` to capabilities and document it's usage.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@waldoapp/wdio-service",
-    "version": "0.2.0",
+    "version": "0.2.2",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "@waldoapp/wdio-service",
-            "version": "0.2.0",
+            "version": "0.2.2",
             "license": "MIT",
             "dependencies": {
                 "@wdio/logger": "^8.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,6 @@
             "dependencies": {
                 "@wdio/logger": "^8.0.0",
                 "axios": "^1.0.0",
-                "lodash": "^4.0.0",
                 "open": "^8.0.0",
                 "sax": "^1.0.0",
                 "webdriver": "^8.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1879,9 +1879,9 @@
             "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="
         },
         "node_modules/axios": {
-            "version": "1.7.2",
-            "resolved": "https://registry.npmjs.org/axios/-/axios-1.7.2.tgz",
-            "integrity": "sha512-2A8QhOMrbomlDuiLeK9XibIBzuHeRcqqNOHp0Cyp5EoJ1IFDh+XZH3A6BkXtv0K4gFGCI0Y4BM7B1wOEi0Rmgw==",
+            "version": "1.7.4",
+            "resolved": "https://registry.npmjs.org/axios/-/axios-1.7.4.tgz",
+            "integrity": "sha512-DukmaFRnY6AzAALSH4J2M3k6PkaC+MfaAGdEERRWcC9q3/TWQwLpHR8ZRLKTdQ3aBDL64EdluRDjJqKw+BPZEw==",
             "dependencies": {
                 "follow-redirects": "^1.15.6",
                 "form-data": "^4.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@waldoapp/wdio-service",
-    "version": "0.2.2",
+    "version": "0.2.3",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "@waldoapp/wdio-service",
-            "version": "0.2.2",
+            "version": "0.2.3",
             "license": "MIT",
             "dependencies": {
                 "@wdio/logger": "^8.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@waldoapp/wdio-service",
-    "version": "0.2.2",
+    "version": "0.2.3",
     "description": "Webdriver.io service for Waldo",
     "homepage": "https://www.waldo.com/scripting",
     "bugs": {

--- a/package.json
+++ b/package.json
@@ -39,7 +39,6 @@
     "dependencies": {
         "@wdio/logger": "^8.0.0",
         "axios": "^1.0.0",
-        "lodash": "^4.0.0",
         "open": "^8.0.0",
         "sax": "^1.0.0",
         "webdriver": "^8.0.0",

--- a/src/utils.test.ts
+++ b/src/utils.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, it, vi, expect } from 'vitest';
-import { waitAsPromise, waitForElement } from './utils.js';
+import { first, last, waitAsPromise, waitForElement } from './utils.js';
 import { attach } from 'webdriverio';
 import { ELEMENT_KEY } from 'webdriver';
 
@@ -123,5 +123,23 @@ describe('waitForElement', () => {
         expect(resolved).toEqual(true);
         const found = await foundPromise;
         expect(found['element-6066-11e4-a52e-4f735466cecf']).toEqual('fake.element.id');
+    });
+});
+
+describe('first', () => {
+    it('handle empty array', () => {
+        expect(first([])).toEqual(undefined);
+    });
+    it('return the first element', () => {
+        expect(first([1, 2, 3])).toEqual(1);
+    });
+});
+
+describe('last', () => {
+    it('handle empty array', () => {
+        expect(last([])).toEqual(undefined);
+    });
+    it('return the last element', () => {
+        expect(last([1, 2, 3])).toEqual(3);
     });
 });

--- a/src/utils.test.ts
+++ b/src/utils.test.ts
@@ -1,0 +1,97 @@
+import { afterEach, beforeEach, describe, it, vi, expect } from 'vitest';
+import { waitAsPromise, waitForElement } from './utils.js';
+import { attach } from 'webdriverio';
+import { ELEMENT_KEY } from 'webdriver';
+
+vi.mock('axios');
+
+beforeEach(() => {
+    vi.useFakeTimers();
+});
+
+afterEach(() => {
+    vi.useRealTimers();
+});
+
+async function getSomeBrowserInstance() {
+    const browser = await attach({
+        options: { capabilities: {} },
+        sessionId: '123456',
+        protocol: 'http',
+        hostname: 'localhost',
+        port: 12345,
+        capabilities: {},
+    });
+    return browser;
+}
+
+describe('waitAsPromise', () => {
+    it('wait as expected', async () => {
+        let completed = false;
+        const promise = waitAsPromise(1000).then(() => {
+            completed = true;
+        });
+        vi.advanceTimersByTime(999);
+        expect(completed).toEqual(false);
+        vi.advanceTimersByTime(1);
+        await promise;
+        expect(completed).toEqual(true);
+    });
+});
+
+async function getFakeBrowser(): Promise<WebdriverIO.Browser> {
+    const someBrowser = await getSomeBrowserInstance();
+    return {
+        options: {
+            protocol: 'http',
+            hostname: 'localhost',
+            port: 12345,
+            capabilities: {},
+            waitforTimeout: 5000,
+            waitforInterval: 500,
+        },
+        waitUntil: someBrowser.waitUntil,
+    } satisfies Partial<WebdriverIO.Browser> as WebdriverIO.Browser;
+}
+
+describe('waitForElement', () => {
+    it('works when the element is already present', async () => {
+        const browser = await getFakeBrowser();
+        browser.findElement = vi.fn(() => Promise.resolve({ [ELEMENT_KEY]: 'fake.element.id' }));
+        const found = await waitForElement(browser, 'selector', 'value');
+        expect(found['element-6066-11e4-a52e-4f735466cecf']).toEqual('fake.element.id');
+    });
+
+    it('fails when the element is not present', async () => {
+        const browser = await getFakeBrowser();
+        browser.findElement = vi.fn(() => Promise.reject(new Error('Not found')));
+        let resolved = false;
+        const foundPromise = waitForElement(browser, 'selector', 'value')
+            .catch((e) => e)
+            .finally(() => {
+                resolved = true;
+            });
+        await vi.advanceTimersByTimeAsync(4999);
+        expect(resolved).toEqual(false);
+        await vi.advanceTimersByTimeAsync(1);
+        expect(resolved).toEqual(true);
+        const found = await foundPromise;
+        expect(found).toBeInstanceOf(Error);
+        expect(found.message).toMatch(/Could not find element with "selector"='value'/);
+    });
+
+    it('works when the element is present after a delay', async () => {
+        const browser = await getFakeBrowser();
+        browser.findElement = vi.fn(() => Promise.reject(new Error('Not found')));
+        let resolved = false;
+        const foundPromise = waitForElement(browser, 'selector', 'value').finally(() => {
+            resolved = true;
+        });
+        await vi.advanceTimersByTimeAsync(1000);
+        browser.findElement = vi.fn(() => Promise.resolve({ [ELEMENT_KEY]: 'fake.element.id' }));
+        await vi.advanceTimersByTimeAsync(500);
+        expect(resolved).toEqual(true);
+        const found = await foundPromise;
+        expect(found['element-6066-11e4-a52e-4f735466cecf']).toEqual('fake.element.id');
+    });
+});

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -284,11 +284,13 @@ export async function waitForElement(
                 const newLocation = await driver.getElementLocation(element[ELEMENT_KEY]);
                 stable = _.isEqual(newLocation, location);
                 location = newLocation;
-            } else {
-                throw new Error(
-                    `Element with "${property}"='${value}' was removed while checking for stability`,
-                );
             }
+        }
+
+        if (!element) {
+            throw new Error(
+                `Element with "${property}"='${value}' was removed while checking for stability`,
+            );
         }
     }
     await logEvent(driver, `Found element "${property}"='${value}'`, logPayload, 'debug');

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -281,7 +281,8 @@ export async function waitForElement(
             }
             element = await tryFindElement(driver, property, value);
             if (element) {
-                const newLocation = await driver.getElementLocation(element[ELEMENT_KEY]);
+                (await driver.$(element)).getLocation();
+                const newLocation = await driver.getElementRect(element[ELEMENT_KEY]);
                 stable = _.isEqual(newLocation, location);
                 location = newLocation;
             }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -238,7 +238,7 @@ export async function waitForElement(
     let element = await tryFindElement(driver, property, value);
     if (!element) {
         try {
-            const remaining = resolvedTimeout - (Date.now() - start);
+            const remaining = resolvedTimeout === 0 ? 0 : resolvedTimeout - (Date.now() - start);
             await driver.waitUntil(
                 async () => {
                     element = await tryFindElement(driver, property, value);
@@ -270,7 +270,7 @@ export async function waitForElement(
         let stable = false;
         let location = {};
         while (!stable) {
-            if (Date.now() - start > resolvedTimeout) {
+            if (resolvedTimeout !== 0 && Date.now() - start > resolvedTimeout) {
                 await logEvent(
                     driver,
                     `Element with "${property}"='${value}' was still not stable`,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -14,7 +14,7 @@
         "isolatedModules": true,
         "removeComments": false,
         "rootDir": "./src",
-        "types": ["node", "@wdio/globals/types", "vitest/globals"]
+        "types": ["node", "@wdio/globals/types"]
     },
     "include": ["src/**/*"]
 }


### PR DESCRIPTION
The code for `waitForElement` was depending on deprecated server behaviour (Responding with a 200 OK and an empty element when a search failed) and didn't work correctly against a conforming server failing with 404 "no such element".

Fix the code and add tests around this function.