### PR TITLE
fix horizontal swipe coordinate calculation in swipeScreen

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,3 +1,7 @@
+## Version 0.2.4
+
+- Fix horizontal swipe coordinate calculation in `swipeScreen`
+
 ## Version 0.2.3
 
 - Fix `waitForElement` to handle more `findElement` return values

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@waldoapp/wdio-service",
-    "version": "0.2.3",
+    "version": "0.2.4",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "@waldoapp/wdio-service",
-            "version": "0.2.3",
+            "version": "0.2.4",
             "license": "MIT",
             "dependencies": {
                 "@wdio/logger": "^8.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@waldoapp/wdio-service",
-    "version": "0.2.3",
+    "version": "0.2.4",
     "description": "Webdriver.io service for Waldo",
     "homepage": "https://www.waldo.com/scripting",
     "bugs": {

--- a/src/utils.test.ts
+++ b/src/utils.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, it, vi, expect } from 'vitest';
-import { first, last, waitAsPromise, waitForElement } from './utils.js';
+import { first, last, performSwipe, swipeScreen, waitAsPromise, waitForElement } from './utils.js';
 import { attach } from 'webdriverio';
 import { ELEMENT_KEY } from 'webdriver';
 
@@ -123,6 +123,119 @@ describe('waitForElement', () => {
         expect(resolved).toEqual(true);
         const found = await foundPromise;
         expect(found['element-6066-11e4-a52e-4f735466cecf']).toEqual('fake.element.id');
+    });
+});
+
+describe('performSwipe', () => {
+    it('call performActions with the expected values', async () => {
+        const browser = await getFakeBrowser();
+        browser.performActions = vi.fn(() => Promise.resolve());
+        await performSwipe(browser, 10, 10, 20, 10);
+        expect(browser.performActions).toHaveBeenCalledTimes(1);
+        expect(browser.performActions).toHaveBeenCalledWith([
+            {
+                type: 'pointer',
+                id: 'finger1',
+                parameters: { pointerType: 'touch' },
+                actions: [
+                    { type: 'pointerMove', x: 10, y: 10, duration: 50 },
+                    { type: 'pointerDown' },
+                    { type: 'pause', duration: 600 },
+                    { type: 'pointerMove', x: 20, y: 10, duration: 50 },
+                    { type: 'pointerUp' },
+                ],
+            },
+        ]);
+    });
+});
+
+describe('swipeScreen', () => {
+    it('works for horizontal defaults', async () => {
+        const browser = await getFakeBrowser();
+        browser._getWindowSize = vi.fn(() => Promise.resolve({ width: 920, height: 1080 }));
+        browser.performActions = vi.fn(() => Promise.resolve());
+        await swipeScreen(browser, 'horizontal');
+        expect(browser.performActions).toHaveBeenCalledTimes(1);
+        expect(browser.performActions).toHaveBeenCalledWith([
+            {
+                type: 'pointer',
+                id: 'finger1',
+                parameters: { pointerType: 'touch' },
+                actions: [
+                    { type: 'pointerMove', x: 920 * 0.95, y: 1080 / 2, duration: 50 },
+                    { type: 'pointerDown' },
+                    { type: 'pause', duration: 600 },
+                    { type: 'pointerMove', x: 920 * 0.05, y: 1080 / 2, duration: 50 },
+                    { type: 'pointerUp' },
+                ],
+            },
+        ]);
+    });
+
+    it('works for horizontal custom', async () => {
+        const browser = await getFakeBrowser();
+        browser._getWindowSize = vi.fn(() => Promise.resolve({ width: 920, height: 1080 }));
+        browser.performActions = vi.fn(() => Promise.resolve());
+        await swipeScreen(browser, 'horizontal', 10, 50);
+        expect(browser.performActions).toHaveBeenCalledTimes(1);
+        expect(browser.performActions).toHaveBeenCalledWith([
+            {
+                type: 'pointer',
+                id: 'finger1',
+                parameters: { pointerType: 'touch' },
+                actions: [
+                    { type: 'pointerMove', x: 920 * 0.1, y: 1080 / 2, duration: 50 },
+                    { type: 'pointerDown' },
+                    { type: 'pause', duration: 600 },
+                    { type: 'pointerMove', x: 920 * 0.5, y: 1080 / 2, duration: 50 },
+                    { type: 'pointerUp' },
+                ],
+            },
+        ]);
+    });
+
+    it('works for vertical defaults', async () => {
+        const browser = await getFakeBrowser();
+        browser._getWindowSize = vi.fn(() => Promise.resolve({ width: 920, height: 1080 }));
+        browser.performActions = vi.fn(() => Promise.resolve());
+        await swipeScreen(browser, 'vertical');
+        expect(browser.performActions).toHaveBeenCalledTimes(1);
+        expect(browser.performActions).toHaveBeenCalledWith([
+            {
+                type: 'pointer',
+                id: 'finger1',
+                parameters: { pointerType: 'touch' },
+                actions: [
+                    { type: 'pointerMove', x: 920 / 2, y: 1080 * 0.95, duration: 50 },
+                    { type: 'pointerDown' },
+                    { type: 'pause', duration: 600 },
+                    { type: 'pointerMove', x: 920 / 2, y: 1080 * 0.05, duration: 50 },
+                    { type: 'pointerUp' },
+                ],
+            },
+        ]);
+    });
+
+    it('works for vertical custom', async () => {
+        const browser = await getFakeBrowser();
+        browser._getWindowSize = vi.fn(() => Promise.resolve({ width: 920, height: 1080 }));
+        browser.performActions = vi.fn(() => Promise.resolve());
+        await swipeScreen(browser, 'vertical', 15, 55);
+        expect(browser.performActions).toHaveBeenCalledTimes(1);
+        expect(browser.performActions).toHaveBeenCalledWith([
+            {
+                type: 'pointer',
+                id: 'finger1',
+                parameters: { pointerType: 'touch' },
+                actions: [
+                    { type: 'pointerMove', x: 920 / 2, y: 1080 * 0.15, duration: 50 },
+                    { type: 'pointerDown' },
+                    { type: 'pause', duration: 600 },
+                    { type: 'pointerMove', x: 920 / 2, y: 1080 * 0.55, duration: 50 },
+                    { type: 'pointerUp' },
+                ],
+            },
+        ]);
     });
 });
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -161,18 +161,22 @@ export async function swipeScreen(
     const swipeDirection = { fromX: 0, fromY: 0, toX: 0, toY: 0 };
     const middleX = Math.round(screen.width / 2);
     const middleY = Math.round(screen.height / 2);
-    if (direction === 'vertical') {
-        swipeDirection.fromX = middleX;
-        swipeDirection.toX = middleX;
-        swipeDirection.fromY = Math.round(screen.height * (fromScreenPercent / 100));
-        swipeDirection.toY = Math.round(screen.height * (toScreenPercent / 100));
+
+    switch (direction) {
+        case 'vertical':
+            swipeDirection.fromX = middleX;
+            swipeDirection.toX = middleX;
+            swipeDirection.fromY = Math.round(screen.height * (fromScreenPercent / 100));
+            swipeDirection.toY = Math.round(screen.height * (toScreenPercent / 100));
+            break;
+        case 'horizontal':
+            swipeDirection.fromY = middleY;
+            swipeDirection.toY = middleY;
+            swipeDirection.fromX = Math.round(screen.width * (fromScreenPercent / 100));
+            swipeDirection.toX = Math.round(screen.width * (toScreenPercent / 100));
+            break;
     }
-    if (direction === 'horizontal') {
-        swipeDirection.fromY = middleY;
-        swipeDirection.toY = middleY;
-        swipeDirection.fromX = Math.round(screen.height * (fromScreenPercent / 100));
-        swipeDirection.toX = Math.round(screen.height * (toScreenPercent / 100));
-    }
+
     await performSwipe(
         driver,
         swipeDirection.fromX,


### PR DESCRIPTION
Computation for the `'horizontal'` case was using the screen `height` instead of `width`.