### PR TITLE
Document coordinateMode capability

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -249,8 +249,9 @@ failed.
 
 ## Waldo service options
 
-To authorize the Waldo service your configuration _must_ contain a token for example in the
-[`key`](https://webdriver.io/docs/options#key) option.
+> ℹ️ **Note**
+> To authorize the Waldo service your configuration _must_ contain a token for example in the
+> [`key`](https://webdriver.io/docs/options#key) option.
 
 ### token
 
@@ -301,9 +302,36 @@ For Appium compatibility, this option can also be specified in the `appium:app` 
 Type: `string` <br/>
 Default: `undefined`
 
+### coordinateMode
+
+> ⚠️️ **Warning**
+>
+> This is iOS specific, sessions on Android will fail to start if this property is specified.
+
+```ts
+'waldo:options': {
+  automationName: 'Waldo',
+  coordinateMode: 'logical',
+},
+```
+
+All coordinates sent in commands or received via the `/source` endpoint can either be in `'logical'` mode, expressed
+in points or in `'device'` mode, expressed in pixels.
+
+```ts
+const points = pixel / screenScale;
+```
+
+- When emulating Appium, the coordinates are always expressed in points (`'logical'`) and specifying any
+  other value will fail.
+- In waldo mode the default is to use pixel coordinates (`'device'`) but this option/capability allow to change it .
+
+Type: `'logical' | 'device'` <br/>
+Default: `undefined` for Android, `'logical'` for Appium iOS, `'device'` for Waldo iOS
+
 ## Device capabilities
 
-Most of the service options can also be specified in the capabilities object for a specific device inside the
+All the service options can also be specified in the capabilities object for a specific device inside the
 `waldo:options` key:
 
 ```ts
@@ -318,9 +346,29 @@ capabilities: [
 ];
 ```
 
-### waldo:automationName
+And all capabilities can also be specified without nesting them inside `waldo:options` by prefixing them with `waldo:`.
+The previous example is equivalent to:
 
-This option can also be specified as `appium:automationName`.
+```ts
+capabilities: [
+  {
+    platformName: 'Android',
+    'waldo:deviceName': 'Pixel 3a',
+    'waldo:showSession': true,
+  },
+];
+```
+
+### automationName
+
+```ts
+'waldo:options': {
+  automationName: 'Waldo',
+},
+```
+
+This option can also be specified as `appium:automationName` or non-prefixed `automationName` directly in the
+capabilities object.
 
 For compatibility, the default behavior of the Waldo service is to return a tree similar to the one returned by Appium,
 this is the equivalent of providing `UiAutomator2`, `UiAutomator2` or `Appium` as the automation name.
@@ -340,8 +388,6 @@ Default: `Appium`
 
 ### deviceName
 
-Placed inside the `waldo:options` object:
-
 ```ts
 'waldo:options': {
   deviceName: 'Pixel 3a',
@@ -356,8 +402,6 @@ Type: `string` <br/>
 Default: `undefined`
 
 ### osVersion
-
-Placed inside the `waldo:options` object:
 
 ```ts
 'waldo:options': {
@@ -383,7 +427,9 @@ This key allows you to specify the language in which the app will run during the
 }
 ```
 
-Please not that each device supports a different set of languages. To determine which languages a specific device supports, you can make a call to the []`GET /devices` endpoint](https://docs.waldo.com/reference/getdevices) on `https://core.waldo.com` and check `supportedLanguages`.
+Please not that each device supports a different set of languages. To determine which languages a specific device
+supports, you can make a call to the []`GET /devices` endpoint](https://docs.waldo.com/reference/getdevices)
+on `https://core.waldo.com` and check `supportedLanguages`.
 
 Type: `string` <br/>
 Default: `en`

--- a/src/launcher.test.ts
+++ b/src/launcher.test.ts
@@ -195,6 +195,35 @@ describe('onPrepare', () => {
             });
         });
 
+        it('can be specified in capabilities waldo:token', async () => {
+            await writeTestProfile('user_token: profile-token');
+
+            const service = new WaldoWdioLauncherService({ token: 'service-token' });
+            const remoteCapabilities: TestrunnerCapabilities = [
+                {
+                    'appium:app': 'appv-12345',
+                    key: 'cap-key-token',
+                    'waldo:token': 'cap-waldo-token',
+                },
+            ];
+            const config: TestRunnerOptionsForTests = { capabilities: {}, key: 'runner-token' };
+            await service.onPrepare(config, remoteCapabilities);
+            expect(remoteCapabilities).toEqual([
+                {
+                    'appium:app': 'appv-12345',
+                    ...PRODUCTION_CONNECTION,
+                    'waldo:options': {
+                        token: 'cap-waldo-token',
+                    },
+                },
+            ]);
+            expect(config).toEqual({
+                capabilities: {},
+                key: 'runner-token',
+                ...PRODUCTION_CONNECTION,
+            });
+        });
+
         it('can be specified in env', async () => {
             await writeTestProfile('user_token: profile-token');
 
@@ -263,6 +292,25 @@ describe('onPrepare', () => {
                 {
                     'appium:app': 'cap-appium-versionId',
                     'waldo:options': { versionId: 'cap-waldo-versionId' },
+                },
+            ];
+            const config: TestRunnerOptionsForTests = { capabilities: {} };
+            await service.onPrepare(config, remoteCapabilities);
+            expect(remoteCapabilities).toEqual([
+                {
+                    'appium:app': 'cap-waldo-versionId',
+                    ...PRODUCTION_CONNECTION,
+                    'waldo:options': {},
+                },
+            ]);
+        });
+
+        it('can be specified in capabilities waldoversionId', async () => {
+            const service = new WaldoWdioLauncherService({ versionId: 'service-versionId' });
+            const remoteCapabilities: TestrunnerCapabilities = [
+                {
+                    'appium:app': 'cap-appium-versionId',
+                    'waldo:versionId': 'cap-waldo-versionId',
                 },
             ];
             const config: TestRunnerOptionsForTests = { capabilities: {} };

--- a/src/launcher.ts
+++ b/src/launcher.ts
@@ -63,7 +63,7 @@ export class WaldoWdioLauncherService implements Services.ServiceInstance {
 
         // Priority order:
         // 1. processEnvConfig: Environment variable
-        // 2. waldoOptions: Waldo specific capabilities
+        // 2. waldoOptions: Waldo specific capabilities (First in waldo:option then prefixed at root)
         // 3. capabilities: Global / appium capabilities
         // 4. serviceOptions: Service option (Passed to the constructor)
         // 5. testRunnerOptions: Test runner option (key, port, hostname, ...)
@@ -75,25 +75,42 @@ export class WaldoWdioLauncherService implements Services.ServiceInstance {
         capabilities['appium:app'] =
             processEnvConfig?.versionId ??
             waldoOptions.versionId ??
+            capabilities['waldo:versionId'] ??
             capabilities['appium:app'] ??
             serviceOptions.versionId;
         delete waldoOptions.versionId;
+        delete capabilities['waldo:versionId'];
 
         waldoOptions.token =
             processEnvConfig.token ??
             waldoOptions.token ??
+            capabilities['waldo:token'] ??
             capabilities.key ??
             serviceOptions.token ??
             testRunnerOptions.key ??
             waldoProfile?.user_token;
         delete capabilities.key;
+        delete capabilities['waldo:token'];
 
         waldoOptions.sessionId =
-            processEnvConfig.sessionId ?? waldoOptions.sessionId ?? serviceOptions.sessionId;
+            processEnvConfig.sessionId ??
+            waldoOptions.sessionId ??
+            capabilities['waldo:sessionId'] ??
+            serviceOptions.sessionId;
+        delete capabilities['waldo:sessionId'];
+
         waldoOptions.waitSessionReady =
-            waldoOptions.waitSessionReady ?? serviceOptions.waitSessionReady;
+            waldoOptions.waitSessionReady ??
+            capabilities['waldo:waitSessionReady'] ??
+            serviceOptions.waitSessionReady;
+        delete capabilities['waldo:waitSessionReady'];
+
         waldoOptions.showSession =
-            processEnvConfig.showSession ?? waldoOptions.showSession ?? serviceOptions.showSession;
+            processEnvConfig.showSession ??
+            waldoOptions.showSession ??
+            capabilities['waldo:showSession'] ??
+            serviceOptions.showSession;
+        delete capabilities['waldo:showSession'];
 
         const hasVersionInformation =
             typeof capabilities['appium:app'] === 'string' ||

--- a/src/types.test.ts
+++ b/src/types.test.ts
@@ -1,0 +1,13 @@
+import { expect, test } from 'vitest';
+import { CapabilitiesWithWaldo } from './types.js';
+
+test('Can build capabilities with and without prefix', () => {
+    const capabilities: CapabilitiesWithWaldo = {
+        'waldo:osVersion': '16.*',
+        'waldo:options': {
+            automationName: 'xcuitest',
+        },
+    };
+
+    expect(capabilities).not.toBeNull();
+});

--- a/src/types.ts
+++ b/src/types.ts
@@ -4,6 +4,12 @@ import { WaldoTree, WaldoTreeElement } from './tree-types.js';
 
 export type WaldoEnvironment = 'production' | 'staging' | 'development';
 
+/**
+ * Indicates if positions and size are logical coordinates in points (`points = pixel / scale`) or device coordinates
+ * in pixels.
+ */
+export type CoordinateMode = 'logical' | 'device';
+
 type WaldoSharedOptions = {
     /**
      * Security token
@@ -44,6 +50,12 @@ type WaldoSharedOptions = {
      * ID (`appv-0123456789abcdef`) of the application version to use for the session.
      */
     versionId?: string;
+
+    /**
+     * Indicates if positions and size are logical coordinates in points (`points = pixel / scale`) or device coordinates
+     * in pixels. (iOS only)
+     */
+    coordinateMode?: CoordinateMode;
 };
 
 export type WaldoCapabilityOptions = WaldoSharedOptions & {

--- a/src/types.ts
+++ b/src/types.ts
@@ -56,11 +56,9 @@ export type WaldoCapabilityOptions = WaldoSharedOptions & {
      * Operating system version to use, like `17.0` or `33.0`
      */
     osVersion?: string;
-};
 
-export type WaldoCapabilities = {
     /** Name of the session that will appear in Waldo session history */
-    'waldo:displayName'?: string;
+    displayName?: string;
 
     /**
      * Type of automation to use
@@ -73,11 +71,17 @@ export type WaldoCapabilities = {
      *
      * Case insensitive
      */
-    'waldo:automationName'?: string;
+    automationName?: string;
+};
 
+type PrefixAllProperties<T, Prefix extends string> = {
+    [K in keyof T as K extends string ? `${Prefix}:${K}` : never]: T[K];
+};
+
+export type WaldoCapabilities = {
     /** Waldo specific options */
     'waldo:options'?: WaldoCapabilityOptions;
-};
+} & PrefixAllProperties<WaldoCapabilityOptions, 'waldo'>;
 
 /**
  * The type for capabilities that the test runner can use.


### PR DESCRIPTION
This documents the new coordinateMode capability and the fact that we support all capabilities `waldo:` prefixed too.

* Fixes https://github.com/waldoapp/backend/issues/10359