### PR TITLE
Packages upgrade

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
             "dependencies": {
                 "@wdio/logger": "^8.0.0 || ^9.0.0",
                 "axios": "^1.0.0",
-                "open": "^8.0.0",
+                "open": "^10.0.0",
                 "sax": "^1.0.0",
                 "webdriver": "^8.0.0 || ^9.0.0",
                 "yaml": "^2.0.0"
@@ -20,38 +20,25 @@
                 "waldo-auth": "dist/bin/waldo-auth.js"
             },
             "devDependencies": {
-                "@eslint/js": "^9.6.0",
+                "@eslint/js": "^9.14.0",
                 "@types/node": "^18.0.0",
                 "@types/sax": "^1.2.7",
                 "@wdio/globals": "^8.0.0 || ^9.0.0",
                 "@wdio/protocols": "^8.0.0 || ^9.0.0",
                 "@wdio/types": "^8.0.0 || ^9.0.0",
-                "eslint": "^9.9.0",
+                "eslint": "^9.14.0",
                 "eslint-config-prettier": "^9.1.0",
-                "memfs": "^4.11.1",
+                "memfs": "^4.14.0",
                 "prettier": "^3.3.3",
-                "typescript": "^5.5.4",
-                "typescript-eslint": "^8.4.0",
-                "vitest": "^2.0.5"
+                "typescript": "^5.6.3",
+                "typescript-eslint": "^8.14.0",
+                "vitest": "^2.1.4"
             },
             "engines": {
                 "node": ">=18"
             },
             "peerDependencies": {
                 "webdriverio": "^8.0.0 || ^9.0.0"
-            }
-        },
-        "node_modules/@ampproject/remapping": {
-            "version": "2.3.0",
-            "resolved": "https://registry.npmjs.org/@ampproject/remapping/-/remapping-2.3.0.tgz",
-            "integrity": "sha512-30iZtAPgz+LTIYoeivqYo853f02jBYSd5uGnGpkFV0M3xOt9aN73erkgYAmZU43x4VfqcnLxW9Kpg3R5LC4YYw==",
-            "dev": true,
-            "dependencies": {
-                "@jridgewell/gen-mapping": "^0.3.5",
-                "@jridgewell/trace-mapping": "^0.3.24"
-            },
-            "engines": {
-                "node": ">=6.0.0"
             }
         },
         "node_modules/@babel/code-frame": {
@@ -516,18 +503,18 @@
             }
         },
         "node_modules/@eslint-community/regexpp": {
-            "version": "4.11.0",
-            "resolved": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.11.0.tgz",
-            "integrity": "sha512-G/M/tIiMrTAxEWRfLfQJMmGNX28IxBg4PBz8XqQhqUHLFI6TL2htpIB1iQCj144V5ee/JaKyT9/WZ0MGZWfA7A==",
+            "version": "4.12.1",
+            "resolved": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.12.1.tgz",
+            "integrity": "sha512-CCZCDJuduB9OUkFkY2IgppNZMi2lBQgD2qzwXkEia16cge2pijY/aXi96CJMquDMn3nJdlPV1A5KrJEXwfLNzQ==",
             "dev": true,
             "engines": {
                 "node": "^12.0.0 || ^14.0.0 || >=16.0.0"
             }
         },
         "node_modules/@eslint/config-array": {
-            "version": "0.17.1",
-            "resolved": "https://registry.npmjs.org/@eslint/config-array/-/config-array-0.17.1.tgz",
-            "integrity": "sha512-BlYOpej8AQ8Ev9xVqroV7a02JK3SkBAaN9GfMMH9W6Ch8FlQlkjGw4Ir7+FgYwfirivAf4t+GtzuAxqfukmISA==",
+            "version": "0.18.0",
+            "resolved": "https://registry.npmjs.org/@eslint/config-array/-/config-array-0.18.0.tgz",
+            "integrity": "sha512-fTxvnS1sRMu3+JjXwJG0j/i4RT9u4qJ+lqS/yCGap4lH4zZGzQ7tu+xZqQmcMZq5OBZDL4QRxQzRjkWcGt8IVw==",
             "dev": true,
             "dependencies": {
                 "@eslint/object-schema": "^2.1.4",
@@ -558,6 +545,15 @@
             },
             "engines": {
                 "node": "*"
+            }
+        },
+        "node_modules/@eslint/core": {
+            "version": "0.7.0",
+            "resolved": "https://registry.npmjs.org/@eslint/core/-/core-0.7.0.tgz",
+            "integrity": "sha512-xp5Jirz5DyPYlPiKat8jaq0EmYvDXKKpzTbxXMpT9eqlRJkRKIz9AGMdlvYjih+im+QlhWrpvVjl8IPC/lHlUw==",
+            "dev": true,
+            "engines": {
+                "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
             }
         },
         "node_modules/@eslint/eslintrc": {
@@ -606,9 +602,9 @@
             }
         },
         "node_modules/@eslint/js": {
-            "version": "9.9.0",
-            "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.9.0.tgz",
-            "integrity": "sha512-hhetes6ZHP3BlXLxmd8K2SNgkhNSi+UcecbnwWKwpP7kyi/uC75DJ1lOOBO3xrC4jyojtGE3YxKZPHfk4yrgug==",
+            "version": "9.14.0",
+            "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.14.0.tgz",
+            "integrity": "sha512-pFoEtFWCPyDOl+C6Ift+wC7Ro89otjigCf5vcuWqWgqNSQbRrpjSvdeE6ofLz4dHmyxD5f7gIdGT4+p36L6Twg==",
             "dev": true,
             "engines": {
                 "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -621,6 +617,53 @@
             "dev": true,
             "engines": {
                 "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+            }
+        },
+        "node_modules/@eslint/plugin-kit": {
+            "version": "0.2.2",
+            "resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.2.2.tgz",
+            "integrity": "sha512-CXtq5nR4Su+2I47WPOlWud98Y5Lv8Kyxp2ukhgFx/eW6Blm18VXJO5WuQylPugRo8nbluoi6GvvxBLqHcvqUUw==",
+            "dev": true,
+            "dependencies": {
+                "levn": "^0.4.1"
+            },
+            "engines": {
+                "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+            }
+        },
+        "node_modules/@humanfs/core": {
+            "version": "0.19.1",
+            "resolved": "https://registry.npmjs.org/@humanfs/core/-/core-0.19.1.tgz",
+            "integrity": "sha512-5DyQ4+1JEUzejeK1JGICcideyfUbGixgS9jNgex5nqkW+cY7WZhxBigmieN5Qnw9ZosSNVC9KQKyb+GUaGyKUA==",
+            "dev": true,
+            "engines": {
+                "node": ">=18.18.0"
+            }
+        },
+        "node_modules/@humanfs/node": {
+            "version": "0.16.6",
+            "resolved": "https://registry.npmjs.org/@humanfs/node/-/node-0.16.6.tgz",
+            "integrity": "sha512-YuI2ZHQL78Q5HbhDiBA1X4LmYdXCKCMQIfw0pw7piHJwyREFebJUvrQN4cMssyES6x+vfUbx1CIpaQUKYdQZOw==",
+            "dev": true,
+            "dependencies": {
+                "@humanfs/core": "^0.19.1",
+                "@humanwhocodes/retry": "^0.3.0"
+            },
+            "engines": {
+                "node": ">=18.18.0"
+            }
+        },
+        "node_modules/@humanfs/node/node_modules/@humanwhocodes/retry": {
+            "version": "0.3.1",
+            "resolved": "https://registry.npmjs.org/@humanwhocodes/retry/-/retry-0.3.1.tgz",
+            "integrity": "sha512-JBxkERygn7Bv/GbN5Rv8Ul6LVknS+5Bp6RgDC/O8gEBU/yeH5Ui5C/OlWrTb6qct7LjjfT6Re2NxB0ln0yYybA==",
+            "dev": true,
+            "engines": {
+                "node": ">=18.18"
+            },
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/nzakas"
             }
         },
         "node_modules/@humanwhocodes/module-importer": {
@@ -637,9 +680,9 @@
             }
         },
         "node_modules/@humanwhocodes/retry": {
-            "version": "0.3.0",
-            "resolved": "https://registry.npmjs.org/@humanwhocodes/retry/-/retry-0.3.0.tgz",
-            "integrity": "sha512-d2CGZR2o7fS6sWB7DG/3a95bGKQyHMACZ5aW8qGkkqQpUoZV6C0X7Pc7l4ZNMZkfNBf4VWNe9E1jRsf0G146Ew==",
+            "version": "0.4.1",
+            "resolved": "https://registry.npmjs.org/@humanwhocodes/retry/-/retry-0.4.1.tgz",
+            "integrity": "sha512-c7hNEllBlenFTHBky65mhq8WD2kbN9Q6gk0bTk8lSBvc554jpXSkST1iePudpt7+A/AQvuHs9EMqjHDXMY1lrA==",
             "dev": true,
             "engines": {
                 "node": ">=18.18"
@@ -833,53 +876,11 @@
                 "node": ">=8"
             }
         },
-        "node_modules/@jridgewell/gen-mapping": {
-            "version": "0.3.5",
-            "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.5.tgz",
-            "integrity": "sha512-IzL8ZoEDIBRWEzlCcRhOaCupYyN5gdIK+Q6fbFdPDg6HqX6jpkItn7DFIpW9LQzXG6Df9sA7+OKnq0qlz/GaQg==",
-            "dev": true,
-            "dependencies": {
-                "@jridgewell/set-array": "^1.2.1",
-                "@jridgewell/sourcemap-codec": "^1.4.10",
-                "@jridgewell/trace-mapping": "^0.3.24"
-            },
-            "engines": {
-                "node": ">=6.0.0"
-            }
-        },
-        "node_modules/@jridgewell/resolve-uri": {
-            "version": "3.1.2",
-            "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
-            "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
-            "dev": true,
-            "engines": {
-                "node": ">=6.0.0"
-            }
-        },
-        "node_modules/@jridgewell/set-array": {
-            "version": "1.2.1",
-            "resolved": "https://registry.npmjs.org/@jridgewell/set-array/-/set-array-1.2.1.tgz",
-            "integrity": "sha512-R8gLRTZeyp03ymzP/6Lil/28tGeGEzhx1q2k703KGWRAI1VdvPIXdG70VJc2pAMw3NA6JKL5hhFu1sJX0Mnn/A==",
-            "dev": true,
-            "engines": {
-                "node": ">=6.0.0"
-            }
-        },
         "node_modules/@jridgewell/sourcemap-codec": {
             "version": "1.5.0",
             "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.0.tgz",
             "integrity": "sha512-gv3ZRaISU3fjPAgNsriBRqGWQL6quFx04YMPW/zD8XMLsU32mhCCbfbO6KZFLjvYpCZ8zyDEgqsgf+PwPaM7GQ==",
             "dev": true
-        },
-        "node_modules/@jridgewell/trace-mapping": {
-            "version": "0.3.25",
-            "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.25.tgz",
-            "integrity": "sha512-vNk6aEwybGtawWmy/PzwnGDOjCkLWSD2wqvjGGAgOAwCGWySYXfYoxt00IJkTF+8Lb57DwOb3Aa0o9CApepiYQ==",
-            "dev": true,
-            "dependencies": {
-                "@jridgewell/resolve-uri": "^3.1.0",
-                "@jridgewell/sourcemap-codec": "^1.4.14"
-            }
         },
         "node_modules/@jsonjoy.com/base64": {
             "version": "1.1.2",
@@ -1297,6 +1298,12 @@
                 "@types/istanbul-lib-report": "*"
             }
         },
+        "node_modules/@types/json-schema": {
+            "version": "7.0.15",
+            "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
+            "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
+            "dev": true
+        },
         "node_modules/@types/node": {
             "version": "18.19.39",
             "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.39.tgz",
@@ -1366,16 +1373,16 @@
             }
         },
         "node_modules/@typescript-eslint/eslint-plugin": {
-            "version": "8.4.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.4.0.tgz",
-            "integrity": "sha512-rg8LGdv7ri3oAlenMACk9e+AR4wUV0yrrG+XKsGKOK0EVgeEDqurkXMPILG2836fW4ibokTB5v4b6Z9+GYQDEw==",
+            "version": "8.14.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.14.0.tgz",
+            "integrity": "sha512-tqp8H7UWFaZj0yNO6bycd5YjMwxa6wIHOLZvWPkidwbgLCsBMetQoGj7DPuAlWa2yGO3H48xmPwjhsSPPCGU5w==",
             "dev": true,
             "dependencies": {
                 "@eslint-community/regexpp": "^4.10.0",
-                "@typescript-eslint/scope-manager": "8.4.0",
-                "@typescript-eslint/type-utils": "8.4.0",
-                "@typescript-eslint/utils": "8.4.0",
-                "@typescript-eslint/visitor-keys": "8.4.0",
+                "@typescript-eslint/scope-manager": "8.14.0",
+                "@typescript-eslint/type-utils": "8.14.0",
+                "@typescript-eslint/utils": "8.14.0",
+                "@typescript-eslint/visitor-keys": "8.14.0",
                 "graphemer": "^1.4.0",
                 "ignore": "^5.3.1",
                 "natural-compare": "^1.4.0",
@@ -1399,15 +1406,15 @@
             }
         },
         "node_modules/@typescript-eslint/parser": {
-            "version": "8.4.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.4.0.tgz",
-            "integrity": "sha512-NHgWmKSgJk5K9N16GIhQ4jSobBoJwrmURaLErad0qlLjrpP5bECYg+wxVTGlGZmJbU03jj/dfnb6V9bw+5icsA==",
+            "version": "8.14.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.14.0.tgz",
+            "integrity": "sha512-2p82Yn9juUJq0XynBXtFCyrBDb6/dJombnz6vbo6mgQEtWHfvHbQuEa9kAOVIt1c9YFwi7H6WxtPj1kg+80+RA==",
             "dev": true,
             "dependencies": {
-                "@typescript-eslint/scope-manager": "8.4.0",
-                "@typescript-eslint/types": "8.4.0",
-                "@typescript-eslint/typescript-estree": "8.4.0",
-                "@typescript-eslint/visitor-keys": "8.4.0",
+                "@typescript-eslint/scope-manager": "8.14.0",
+                "@typescript-eslint/types": "8.14.0",
+                "@typescript-eslint/typescript-estree": "8.14.0",
+                "@typescript-eslint/visitor-keys": "8.14.0",
                 "debug": "^4.3.4"
             },
             "engines": {
@@ -1427,13 +1434,13 @@
             }
         },
         "node_modules/@typescript-eslint/scope-manager": {
-            "version": "8.4.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.4.0.tgz",
-            "integrity": "sha512-n2jFxLeY0JmKfUqy3P70rs6vdoPjHK8P/w+zJcV3fk0b0BwRXC/zxRTEnAsgYT7MwdQDt/ZEbtdzdVC+hcpF0A==",
+            "version": "8.14.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.14.0.tgz",
+            "integrity": "sha512-aBbBrnW9ARIDn92Zbo7rguLnqQ/pOrUguVpbUwzOhkFg2npFDwTgPGqFqE0H5feXcOoJOfX3SxlJaKEVtq54dw==",
             "dev": true,
             "dependencies": {
-                "@typescript-eslint/types": "8.4.0",
-                "@typescript-eslint/visitor-keys": "8.4.0"
+                "@typescript-eslint/types": "8.14.0",
+                "@typescript-eslint/visitor-keys": "8.14.0"
             },
             "engines": {
                 "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -1444,13 +1451,13 @@
             }
         },
         "node_modules/@typescript-eslint/type-utils": {
-            "version": "8.4.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.4.0.tgz",
-            "integrity": "sha512-pu2PAmNrl9KX6TtirVOrbLPLwDmASpZhK/XU7WvoKoCUkdtq9zF7qQ7gna0GBZFN0hci0vHaSusiL2WpsQk37A==",
+            "version": "8.14.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.14.0.tgz",
+            "integrity": "sha512-Xcz9qOtZuGusVOH5Uk07NGs39wrKkf3AxlkK79RBK6aJC1l03CobXjJbwBPSidetAOV+5rEVuiT1VSBUOAsanQ==",
             "dev": true,
             "dependencies": {
-                "@typescript-eslint/typescript-estree": "8.4.0",
-                "@typescript-eslint/utils": "8.4.0",
+                "@typescript-eslint/typescript-estree": "8.14.0",
+                "@typescript-eslint/utils": "8.14.0",
                 "debug": "^4.3.4",
                 "ts-api-utils": "^1.3.0"
             },
@@ -1468,9 +1475,9 @@
             }
         },
         "node_modules/@typescript-eslint/types": {
-            "version": "8.4.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.4.0.tgz",
-            "integrity": "sha512-T1RB3KQdskh9t3v/qv7niK6P8yvn7ja1mS7QK7XfRVL6wtZ8/mFs/FHf4fKvTA0rKnqnYxl/uHFNbnEt0phgbw==",
+            "version": "8.14.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.14.0.tgz",
+            "integrity": "sha512-yjeB9fnO/opvLJFAsPNYlKPnEM8+z4og09Pk504dkqonT02AyL5Z9SSqlE0XqezS93v6CXn49VHvB2G7XSsl0g==",
             "dev": true,
             "engines": {
                 "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -1481,13 +1488,13 @@
             }
         },
         "node_modules/@typescript-eslint/typescript-estree": {
-            "version": "8.4.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.4.0.tgz",
-            "integrity": "sha512-kJ2OIP4dQw5gdI4uXsaxUZHRwWAGpREJ9Zq6D5L0BweyOrWsL6Sz0YcAZGWhvKnH7fm1J5YFE1JrQL0c9dd53A==",
+            "version": "8.14.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.14.0.tgz",
+            "integrity": "sha512-OPXPLYKGZi9XS/49rdaCbR5j/S14HazviBlUQFvSKz3npr3NikF+mrgK7CFVur6XEt95DZp/cmke9d5i3vtVnQ==",
             "dev": true,
             "dependencies": {
-                "@typescript-eslint/types": "8.4.0",
-                "@typescript-eslint/visitor-keys": "8.4.0",
+                "@typescript-eslint/types": "8.14.0",
+                "@typescript-eslint/visitor-keys": "8.14.0",
                 "debug": "^4.3.4",
                 "fast-glob": "^3.3.2",
                 "is-glob": "^4.0.3",
@@ -1509,15 +1516,15 @@
             }
         },
         "node_modules/@typescript-eslint/utils": {
-            "version": "8.4.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.4.0.tgz",
-            "integrity": "sha512-swULW8n1IKLjRAgciCkTCafyTHHfwVQFt8DovmaF69sKbOxTSFMmIZaSHjqO9i/RV0wIblaawhzvtva8Nmm7lQ==",
+            "version": "8.14.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.14.0.tgz",
+            "integrity": "sha512-OGqj6uB8THhrHj0Fk27DcHPojW7zKwKkPmHXHvQ58pLYp4hy8CSUdTKykKeh+5vFqTTVmjz0zCOOPKRovdsgHA==",
             "dev": true,
             "dependencies": {
                 "@eslint-community/eslint-utils": "^4.4.0",
-                "@typescript-eslint/scope-manager": "8.4.0",
-                "@typescript-eslint/types": "8.4.0",
-                "@typescript-eslint/typescript-estree": "8.4.0"
+                "@typescript-eslint/scope-manager": "8.14.0",
+                "@typescript-eslint/types": "8.14.0",
+                "@typescript-eslint/typescript-estree": "8.14.0"
             },
             "engines": {
                 "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -1531,12 +1538,12 @@
             }
         },
         "node_modules/@typescript-eslint/visitor-keys": {
-            "version": "8.4.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.4.0.tgz",
-            "integrity": "sha512-zTQD6WLNTre1hj5wp09nBIDiOc2U5r/qmzo7wxPn4ZgAjHql09EofqhF9WF+fZHzL5aCyaIpPcT2hyxl73kr9A==",
+            "version": "8.14.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.14.0.tgz",
+            "integrity": "sha512-vG0XZo8AdTH9OE6VFRwAZldNc7qtJ/6NLGWak+BtENuEUXGZgFpihILPiBvKXvJ2nFu27XNGC6rKiwuaoMbYzQ==",
             "dev": true,
             "dependencies": {
-                "@typescript-eslint/types": "8.4.0",
+                "@typescript-eslint/types": "8.14.0",
                 "eslint-visitor-keys": "^3.4.3"
             },
             "engines": {
@@ -1548,24 +1555,50 @@
             }
         },
         "node_modules/@vitest/expect": {
-            "version": "2.0.5",
-            "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-2.0.5.tgz",
-            "integrity": "sha512-yHZtwuP7JZivj65Gxoi8upUN2OzHTi3zVfjwdpu2WrvCZPLwsJ2Ey5ILIPccoW23dd/zQBlJ4/dhi7DWNyXCpA==",
+            "version": "2.1.4",
+            "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-2.1.4.tgz",
+            "integrity": "sha512-DOETT0Oh1avie/D/o2sgMHGrzYUFFo3zqESB2Hn70z6QB1HrS2IQ9z5DfyTqU8sg4Bpu13zZe9V4+UTNQlUeQA==",
             "dev": true,
             "dependencies": {
-                "@vitest/spy": "2.0.5",
-                "@vitest/utils": "2.0.5",
-                "chai": "^5.1.1",
+                "@vitest/spy": "2.1.4",
+                "@vitest/utils": "2.1.4",
+                "chai": "^5.1.2",
                 "tinyrainbow": "^1.2.0"
             },
             "funding": {
                 "url": "https://opencollective.com/vitest"
             }
         },
+        "node_modules/@vitest/mocker": {
+            "version": "2.1.4",
+            "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-2.1.4.tgz",
+            "integrity": "sha512-Ky/O1Lc0QBbutJdW0rqLeFNbuLEyS+mIPiNdlVlp2/yhJ0SbyYqObS5IHdhferJud8MbbwMnexg4jordE5cCoQ==",
+            "dev": true,
+            "dependencies": {
+                "@vitest/spy": "2.1.4",
+                "estree-walker": "^3.0.3",
+                "magic-string": "^0.30.12"
+            },
+            "funding": {
+                "url": "https://opencollective.com/vitest"
+            },
+            "peerDependencies": {
+                "msw": "^2.4.9",
+                "vite": "^5.0.0"
+            },
+            "peerDependenciesMeta": {
+                "msw": {
+                    "optional": true
+                },
+                "vite": {
+                    "optional": true
+                }
+            }
+        },
         "node_modules/@vitest/pretty-format": {
-            "version": "2.0.5",
-            "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-2.0.5.tgz",
-            "integrity": "sha512-h8k+1oWHfwTkyTkb9egzwNMfJAEx4veaPSnMeKbVSjp4euqGSbQlm5+6VHwTr7u4FJslVVsUG5nopCaAYdOmSQ==",
+            "version": "2.1.4",
+            "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-2.1.4.tgz",
+            "integrity": "sha512-L95zIAkEuTDbUX1IsjRl+vyBSLh3PwLLgKpghl37aCK9Jvw0iP+wKwIFhfjdUtA2myLgjrG6VU6JCFLv8q/3Ww==",
             "dev": true,
             "dependencies": {
                 "tinyrainbow": "^1.2.0"
@@ -1575,12 +1608,12 @@
             }
         },
         "node_modules/@vitest/runner": {
-            "version": "2.0.5",
-            "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-2.0.5.tgz",
-            "integrity": "sha512-TfRfZa6Bkk9ky4tW0z20WKXFEwwvWhRY+84CnSEtq4+3ZvDlJyY32oNTJtM7AW9ihW90tX/1Q78cb6FjoAs+ig==",
+            "version": "2.1.4",
+            "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-2.1.4.tgz",
+            "integrity": "sha512-sKRautINI9XICAMl2bjxQM8VfCMTB0EbsBc/EDFA57V6UQevEKY/TOPOF5nzcvCALltiLfXWbq4MaAwWx/YxIA==",
             "dev": true,
             "dependencies": {
-                "@vitest/utils": "2.0.5",
+                "@vitest/utils": "2.1.4",
                 "pathe": "^1.1.2"
             },
             "funding": {
@@ -1588,13 +1621,13 @@
             }
         },
         "node_modules/@vitest/snapshot": {
-            "version": "2.0.5",
-            "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-2.0.5.tgz",
-            "integrity": "sha512-SgCPUeDFLaM0mIUHfaArq8fD2WbaXG/zVXjRupthYfYGzc8ztbFbu6dUNOblBG7XLMR1kEhS/DNnfCZ2IhdDew==",
+            "version": "2.1.4",
+            "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-2.1.4.tgz",
+            "integrity": "sha512-3Kab14fn/5QZRog5BPj6Rs8dc4B+mim27XaKWFWHWA87R56AKjHTGcBFKpvZKDzC4u5Wd0w/qKsUIio3KzWW4Q==",
             "dev": true,
             "dependencies": {
-                "@vitest/pretty-format": "2.0.5",
-                "magic-string": "^0.30.10",
+                "@vitest/pretty-format": "2.1.4",
+                "magic-string": "^0.30.12",
                 "pathe": "^1.1.2"
             },
             "funding": {
@@ -1602,26 +1635,25 @@
             }
         },
         "node_modules/@vitest/spy": {
-            "version": "2.0.5",
-            "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-2.0.5.tgz",
-            "integrity": "sha512-c/jdthAhvJdpfVuaexSrnawxZz6pywlTPe84LUB2m/4t3rl2fTo9NFGBG4oWgaD+FTgDDV8hJ/nibT7IfH3JfA==",
+            "version": "2.1.4",
+            "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-2.1.4.tgz",
+            "integrity": "sha512-4JOxa+UAizJgpZfaCPKK2smq9d8mmjZVPMt2kOsg/R8QkoRzydHH1qHxIYNvr1zlEaFj4SXiaaJWxq/LPLKaLg==",
             "dev": true,
             "dependencies": {
-                "tinyspy": "^3.0.0"
+                "tinyspy": "^3.0.2"
             },
             "funding": {
                 "url": "https://opencollective.com/vitest"
             }
         },
         "node_modules/@vitest/utils": {
-            "version": "2.0.5",
-            "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-2.0.5.tgz",
-            "integrity": "sha512-d8HKbqIcya+GR67mkZbrzhS5kKhtp8dQLcmRZLGTscGVg7yImT82cIrhtn2L8+VujWcy6KZweApgNmPsTAO/UQ==",
+            "version": "2.1.4",
+            "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-2.1.4.tgz",
+            "integrity": "sha512-MXDnZn0Awl2S86PSNIim5PWXgIAx8CIkzu35mBdSApUip6RFOGXBCf3YFyeEu8n1IHk4bWD46DeYFu9mQlFIRg==",
             "dev": true,
             "dependencies": {
-                "@vitest/pretty-format": "2.0.5",
-                "estree-walker": "^3.0.3",
-                "loupe": "^3.1.1",
+                "@vitest/pretty-format": "2.1.4",
+                "loupe": "^3.1.2",
                 "tinyrainbow": "^1.2.0"
             },
             "funding": {
@@ -1770,9 +1802,9 @@
             }
         },
         "node_modules/acorn": {
-            "version": "8.12.1",
-            "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.12.1.tgz",
-            "integrity": "sha512-tcpGyI9zbizT9JbV6oYE477V6mTlXvvi0T0G3SNIYE2apm/G5huBa1+K89VGeovbg+jycCrfhl3ADxErOuO6Jg==",
+            "version": "8.14.0",
+            "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.14.0.tgz",
+            "integrity": "sha512-cl669nCJTZBsL97OF4kUQm5g5hC2uihk0NxY3WENAC0TYdILVkAyHymAntgxGkl7K+t0cXIrH5siy5S4XkFycA==",
             "dev": true,
             "bin": {
                 "acorn": "bin/acorn"
@@ -2074,6 +2106,20 @@
                 "node": ">=8.0.0"
             }
         },
+        "node_modules/bundle-name": {
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/bundle-name/-/bundle-name-4.1.0.tgz",
+            "integrity": "sha512-tjwM5exMg6BGRI+kNmTntNsvdZS1X8BFYS6tnJ2hdH0kVxM6/eVZ2xy+FqStSWvYmtfFMDLIxurorHwDKfDz5Q==",
+            "dependencies": {
+                "run-applescript": "^7.0.0"
+            },
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
         "node_modules/cac": {
             "version": "6.7.14",
             "resolved": "https://registry.npmjs.org/cac/-/cac-6.7.14.tgz",
@@ -2093,9 +2139,9 @@
             }
         },
         "node_modules/chai": {
-            "version": "5.1.1",
-            "resolved": "https://registry.npmjs.org/chai/-/chai-5.1.1.tgz",
-            "integrity": "sha512-pT1ZgP8rPNqUgieVaEY+ryQr6Q4HXNg8Ei9UnLUrjN4IA7dvQC5JB+/kxVcPNDHyBcc/26CXPkbNzq3qwrOEKA==",
+            "version": "5.1.2",
+            "resolved": "https://registry.npmjs.org/chai/-/chai-5.1.2.tgz",
+            "integrity": "sha512-aGtmf24DW6MLHHG5gCx4zaI3uBq3KRtxeVs0DjFH6Z0rDNbsvTxFASFvdj79pxjxZ8/5u3PIiN3IwEIQkiiuPw==",
             "dev": true,
             "dependencies": {
                 "assertion-error": "^2.0.1",
@@ -2385,11 +2431,11 @@
             }
         },
         "node_modules/debug": {
-            "version": "4.3.6",
-            "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.6.tgz",
-            "integrity": "sha512-O/09Bd4Z1fBrU4VzkhFqVgpPzaGbw6Sm9FEkBT1A/YBXQFGuuSxa1dN2nxgxS34JmKXqYx8CZAwEVoJFImUXIg==",
+            "version": "4.3.7",
+            "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.7.tgz",
+            "integrity": "sha512-Er2nc/H7RrMXZBFCEim6TCmMk02Z8vLC2Rbi1KEBggpo0fS6l0S1nnapwmIi3yW/+GOJap1Krg4w0Hg80oCqgQ==",
             "dependencies": {
-                "ms": "2.1.2"
+                "ms": "^2.1.3"
             },
             "engines": {
                 "node": ">=6.0"
@@ -2434,12 +2480,41 @@
                 "node": ">=16.0.0"
             }
         },
-        "node_modules/define-lazy-prop": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/define-lazy-prop/-/define-lazy-prop-2.0.0.tgz",
-            "integrity": "sha512-Ds09qNh8yw3khSjiJjiUInaGX9xlqZDY7JVryGxdxV7NPeuqQfplOpQ66yJFZut3jLa5zOwkXw1g9EI2uKh4Og==",
+        "node_modules/default-browser": {
+            "version": "5.2.1",
+            "resolved": "https://registry.npmjs.org/default-browser/-/default-browser-5.2.1.tgz",
+            "integrity": "sha512-WY/3TUME0x3KPYdRRxEJJvXRHV4PyPoUsxtZa78lwItwRQRHhd2U9xOscaT/YTf8uCXIAjeJOFBVEh/7FtD8Xg==",
+            "dependencies": {
+                "bundle-name": "^4.1.0",
+                "default-browser-id": "^5.0.0"
+            },
             "engines": {
-                "node": ">=8"
+                "node": ">=18"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/default-browser-id": {
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/default-browser-id/-/default-browser-id-5.0.0.tgz",
+            "integrity": "sha512-A6p/pu/6fyBcA1TRz/GqWYPViplrftcW2gZC9q79ngNCKAeR/X3gcEdXQHl4KNXV+3wgIJ1CPkJQ3IHM6lcsyA==",
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/define-lazy-prop": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/define-lazy-prop/-/define-lazy-prop-3.0.0.tgz",
+            "integrity": "sha512-N+MeXYoqr3pOgn8xfyRPREN7gHakLYjhsHhWGT3fWAiL4IkAt0iDw14QiiEm2bE30c5XX5q0FtAA3CK5f9/BUg==",
+            "engines": {
+                "node": ">=12"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
             }
         },
         "node_modules/degenerator": {
@@ -2728,27 +2803,31 @@
             }
         },
         "node_modules/eslint": {
-            "version": "9.9.0",
-            "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.9.0.tgz",
-            "integrity": "sha512-JfiKJrbx0506OEerjK2Y1QlldtBxkAlLxT5OEcRF8uaQ86noDe2k31Vw9rnSWv+MXZHj7OOUV/dA0AhdLFcyvA==",
+            "version": "9.14.0",
+            "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.14.0.tgz",
+            "integrity": "sha512-c2FHsVBr87lnUtjP4Yhvk4yEhKrQavGafRA/Se1ouse8PfbfC/Qh9Mxa00yWsZRlqeUB9raXip0aiiUZkgnr9g==",
             "dev": true,
             "dependencies": {
                 "@eslint-community/eslint-utils": "^4.2.0",
-                "@eslint-community/regexpp": "^4.11.0",
-                "@eslint/config-array": "^0.17.1",
+                "@eslint-community/regexpp": "^4.12.1",
+                "@eslint/config-array": "^0.18.0",
+                "@eslint/core": "^0.7.0",
                 "@eslint/eslintrc": "^3.1.0",
-                "@eslint/js": "9.9.0",
+                "@eslint/js": "9.14.0",
+                "@eslint/plugin-kit": "^0.2.0",
+                "@humanfs/node": "^0.16.6",
                 "@humanwhocodes/module-importer": "^1.0.1",
-                "@humanwhocodes/retry": "^0.3.0",
-                "@nodelib/fs.walk": "^1.2.8",
+                "@humanwhocodes/retry": "^0.4.0",
+                "@types/estree": "^1.0.6",
+                "@types/json-schema": "^7.0.15",
                 "ajv": "^6.12.4",
                 "chalk": "^4.0.0",
                 "cross-spawn": "^7.0.2",
                 "debug": "^4.3.2",
                 "escape-string-regexp": "^4.0.0",
-                "eslint-scope": "^8.0.2",
-                "eslint-visitor-keys": "^4.0.0",
-                "espree": "^10.1.0",
+                "eslint-scope": "^8.2.0",
+                "eslint-visitor-keys": "^4.2.0",
+                "espree": "^10.3.0",
                 "esquery": "^1.5.0",
                 "esutils": "^2.0.2",
                 "fast-deep-equal": "^3.1.3",
@@ -2758,14 +2837,11 @@
                 "ignore": "^5.2.0",
                 "imurmurhash": "^0.1.4",
                 "is-glob": "^4.0.0",
-                "is-path-inside": "^3.0.3",
                 "json-stable-stringify-without-jsonify": "^1.0.1",
-                "levn": "^0.4.1",
                 "lodash.merge": "^4.6.2",
                 "minimatch": "^3.1.2",
                 "natural-compare": "^1.4.0",
                 "optionator": "^0.9.3",
-                "strip-ansi": "^6.0.1",
                 "text-table": "^0.2.0"
             },
             "bin": {
@@ -2799,9 +2875,9 @@
             }
         },
         "node_modules/eslint-scope": {
-            "version": "8.0.2",
-            "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-8.0.2.tgz",
-            "integrity": "sha512-6E4xmrTw5wtxnLA5wYL3WDfhZ/1bUBGOXV0zQvVRDOtrR8D0p6W7fs3JweNYhwRYeGvd/1CKX2se0/2s7Q/nJA==",
+            "version": "8.2.0",
+            "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-8.2.0.tgz",
+            "integrity": "sha512-PHlWUfG6lvPc3yvP5A4PNyBL1W8fkDUccmI21JUu/+GKZBoH/W5u6usENXUrWFRsyoW5ACUjFGgAFQp5gUlb/A==",
             "dev": true,
             "dependencies": {
                 "esrecurse": "^4.3.0",
@@ -2824,15 +2900,6 @@
             },
             "funding": {
                 "url": "https://opencollective.com/eslint"
-            }
-        },
-        "node_modules/eslint/node_modules/ansi-regex": {
-            "version": "5.0.1",
-            "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
-            "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
-            "dev": true,
-            "engines": {
-                "node": ">=8"
             }
         },
         "node_modules/eslint/node_modules/ansi-styles": {
@@ -2895,9 +2962,9 @@
             "dev": true
         },
         "node_modules/eslint/node_modules/eslint-visitor-keys": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-4.0.0.tgz",
-            "integrity": "sha512-OtIRv/2GyiF6o/d8K7MYKKbXrOUBIK6SfkIRM4Z0dY3w+LiQ0vy3F57m0Z71bjbyeiWFiHJ8brqnmE6H6/jEuw==",
+            "version": "4.2.0",
+            "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-4.2.0.tgz",
+            "integrity": "sha512-UyLnSehNt62FFhSwjZlHmeokpRK59rcz29j+F1/aDgbkbRTk7wIc9XzdoasMUbRNKDM0qQt/+BJ4BrpFeABemw==",
             "dev": true,
             "engines": {
                 "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -2927,18 +2994,6 @@
                 "node": "*"
             }
         },
-        "node_modules/eslint/node_modules/strip-ansi": {
-            "version": "6.0.1",
-            "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
-            "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
-            "dev": true,
-            "dependencies": {
-                "ansi-regex": "^5.0.1"
-            },
-            "engines": {
-                "node": ">=8"
-            }
-        },
         "node_modules/eslint/node_modules/supports-color": {
             "version": "7.2.0",
             "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
@@ -2952,14 +3007,14 @@
             }
         },
         "node_modules/espree": {
-            "version": "10.1.0",
-            "resolved": "https://registry.npmjs.org/espree/-/espree-10.1.0.tgz",
-            "integrity": "sha512-M1M6CpiE6ffoigIOWYO9UDP8TMUw9kqb21tf+08IgDYjCsOvCuDt4jQcZmoYxx+w7zlKw9/N0KXfto+I8/FrXA==",
+            "version": "10.3.0",
+            "resolved": "https://registry.npmjs.org/espree/-/espree-10.3.0.tgz",
+            "integrity": "sha512-0QYC8b24HWY8zjRnDTL6RiHfDbAWn63qb4LMj1Z4b076A4une81+z03Kg7l7mn/48PUTqoLptSXez8oknU8Clg==",
             "dev": true,
             "dependencies": {
-                "acorn": "^8.12.0",
+                "acorn": "^8.14.0",
                 "acorn-jsx": "^5.3.2",
-                "eslint-visitor-keys": "^4.0.0"
+                "eslint-visitor-keys": "^4.2.0"
             },
             "engines": {
                 "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -2969,9 +3024,9 @@
             }
         },
         "node_modules/espree/node_modules/eslint-visitor-keys": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-4.0.0.tgz",
-            "integrity": "sha512-OtIRv/2GyiF6o/d8K7MYKKbXrOUBIK6SfkIRM4Z0dY3w+LiQ0vy3F57m0Z71bjbyeiWFiHJ8brqnmE6H6/jEuw==",
+            "version": "4.2.0",
+            "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-4.2.0.tgz",
+            "integrity": "sha512-UyLnSehNt62FFhSwjZlHmeokpRK59rcz29j+F1/aDgbkbRTk7wIc9XzdoasMUbRNKDM0qQt/+BJ4BrpFeABemw==",
             "dev": true,
             "engines": {
                 "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -3057,29 +3112,6 @@
                 "node": ">=0.8.x"
             }
         },
-        "node_modules/execa": {
-            "version": "8.0.1",
-            "resolved": "https://registry.npmjs.org/execa/-/execa-8.0.1.tgz",
-            "integrity": "sha512-VyhnebXciFV2DESc+p6B+y0LjSm0krU4OgJN44qFAhBY0TJ+1V61tYD2+wHusZ6F9n5K+vl8k0sTy7PEfV4qpg==",
-            "dev": true,
-            "dependencies": {
-                "cross-spawn": "^7.0.3",
-                "get-stream": "^8.0.1",
-                "human-signals": "^5.0.0",
-                "is-stream": "^3.0.0",
-                "merge-stream": "^2.0.0",
-                "npm-run-path": "^5.1.0",
-                "onetime": "^6.0.0",
-                "signal-exit": "^4.1.0",
-                "strip-final-newline": "^3.0.0"
-            },
-            "engines": {
-                "node": ">=16.17"
-            },
-            "funding": {
-                "url": "https://github.com/sindresorhus/execa?sponsor=1"
-            }
-        },
         "node_modules/expect": {
             "version": "29.7.0",
             "resolved": "https://registry.npmjs.org/expect/-/expect-29.7.0.tgz",
@@ -3095,6 +3127,15 @@
             },
             "engines": {
                 "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+            }
+        },
+        "node_modules/expect-type": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.1.0.tgz",
+            "integrity": "sha512-bFi65yM+xZgk+u/KRIpekdSYkTB5W1pEf0Lt8Q8Msh7b+eQ7LXVtIB1Bkm4fvclDEL1b2CZkMhv2mOeF8tMdkA==",
+            "dev": true,
+            "engines": {
+                "node": ">=12.0.0"
             }
         },
         "node_modules/expect-webdriverio": {
@@ -3469,31 +3510,10 @@
                 "node": "6.* || 8.* || >= 10.*"
             }
         },
-        "node_modules/get-func-name": {
-            "version": "2.0.2",
-            "resolved": "https://registry.npmjs.org/get-func-name/-/get-func-name-2.0.2.tgz",
-            "integrity": "sha512-8vXOvuE167CtIc3OyItco7N/dpRtBbYOsPsXCz7X/PMnlGjYjSGuZJgM1Y7mmew7BKf9BqvLX2tnOVy1BBUsxQ==",
-            "dev": true,
-            "engines": {
-                "node": "*"
-            }
-        },
         "node_modules/get-port": {
             "version": "7.1.0",
             "resolved": "https://registry.npmjs.org/get-port/-/get-port-7.1.0.tgz",
             "integrity": "sha512-QB9NKEeDg3xxVwCCwJQ9+xycaz6pBB6iQ76wiWMl1927n0Kir6alPiP+yuiICLLU4jpMe08dXfpebuQppFA2zw==",
-            "engines": {
-                "node": ">=16"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
-        "node_modules/get-stream": {
-            "version": "8.0.1",
-            "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-8.0.1.tgz",
-            "integrity": "sha512-VaUJspBffn/LMCJVoMvSAdmscJyS1auj5Zulnn5UoYcY531UWmdwhRWkcGKnGU93m5HSXP9LP2usOryrBtQowA==",
-            "dev": true,
             "engines": {
                 "node": ">=16"
             },
@@ -3639,15 +3659,6 @@
                 "node": ">= 14"
             }
         },
-        "node_modules/human-signals": {
-            "version": "5.0.0",
-            "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-5.0.0.tgz",
-            "integrity": "sha512-AXcZb6vzzrFAUE61HnN4mpLqd/cSIwNQjtNWR0euPm6y0iqx3G4gOXaIDdtdDwZmhwe82LA6+zinmW4UBWVePQ==",
-            "dev": true,
-            "engines": {
-                "node": ">=16.17.0"
-            }
-        },
         "node_modules/hyperdyperid": {
             "version": "1.2.0",
             "resolved": "https://registry.npmjs.org/hyperdyperid/-/hyperdyperid-1.2.0.tgz",
@@ -3753,14 +3764,14 @@
             }
         },
         "node_modules/is-docker": {
-            "version": "2.2.1",
-            "resolved": "https://registry.npmjs.org/is-docker/-/is-docker-2.2.1.tgz",
-            "integrity": "sha512-F+i2BKsFrH66iaUFc0woD8sLy8getkwTwtOBjvs56Cx4CgJDeKQeqfz8wAYiSb8JOprWhHH5p77PbmYCvvUuXQ==",
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/is-docker/-/is-docker-3.0.0.tgz",
+            "integrity": "sha512-eljcgEDlEns/7AXFosB5K/2nCM4P7FQPkGc/DWLy5rmFEWvZayGrik1d9/QIY5nJ4f9YsVvBkA6kJpHn9rISdQ==",
             "bin": {
                 "is-docker": "cli.js"
             },
             "engines": {
-                "node": ">=8"
+                "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
             },
             "funding": {
                 "url": "https://github.com/sponsors/sindresorhus"
@@ -3795,6 +3806,23 @@
                 "node": ">=0.10.0"
             }
         },
+        "node_modules/is-inside-container": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/is-inside-container/-/is-inside-container-1.0.0.tgz",
+            "integrity": "sha512-KIYLCCJghfHZxqjYBE7rEy0OBuTd5xCHS7tHVgvCLkx7StIoaxwNW3hCALgEUjFfeRk+MG/Qxmp/vtETEF3tRA==",
+            "dependencies": {
+                "is-docker": "^3.0.0"
+            },
+            "bin": {
+                "is-inside-container": "cli.js"
+            },
+            "engines": {
+                "node": ">=14.16"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
         "node_modules/is-number": {
             "version": "7.0.0",
             "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
@@ -3802,15 +3830,6 @@
             "dev": true,
             "engines": {
                 "node": ">=0.12.0"
-            }
-        },
-        "node_modules/is-path-inside": {
-            "version": "3.0.3",
-            "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-3.0.3.tgz",
-            "integrity": "sha512-Fd4gABb+ycGAmKou8eMftCupSir5lRxqf4aD/vd0cD2qc4HL07OjCeuHMr8Ro4CoMaeCKDB0/ECBOVWjTwUvPQ==",
-            "dev": true,
-            "engines": {
-                "node": ">=8"
             }
         },
         "node_modules/is-plain-obj": {
@@ -3824,27 +3843,18 @@
                 "url": "https://github.com/sponsors/sindresorhus"
             }
         },
-        "node_modules/is-stream": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-3.0.0.tgz",
-            "integrity": "sha512-LnQR4bZ9IADDRSkvpqMGvt/tEJWclzklNgSw48V5EAaAeDd6qGvN8ei6k5p0tvxSR171VmGyHuTiAOfxAbr8kA==",
-            "dev": true,
+        "node_modules/is-wsl": {
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-3.1.0.tgz",
+            "integrity": "sha512-UcVfVfaK4Sc4m7X3dUSoHoozQGBEFeDC+zVo06t98xe8CzHSZZBekNXH+tu0NalHolcJ/QAGqS46Hef7QXBIMw==",
+            "dependencies": {
+                "is-inside-container": "^1.0.0"
+            },
             "engines": {
-                "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+                "node": ">=16"
             },
             "funding": {
                 "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
-        "node_modules/is-wsl": {
-            "version": "2.2.0",
-            "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-2.2.0.tgz",
-            "integrity": "sha512-fKzAra0rGJUUBwGBgNkHZuToZcn+TtXHpeCgmkMJMMYx1sQDYaCSyjJBSCa2nH1DGm7s3n1oBnohoVTBaN7Lww==",
-            "dependencies": {
-                "is-docker": "^2.0.0"
-            },
-            "engines": {
-                "node": ">=8"
             }
         },
         "node_modules/isexe": {
@@ -4504,13 +4514,10 @@
             "integrity": "sha512-WpG9CcFAOjz/FtNht+QJeGpvVl/cdR6P0z6OcXSkr8wFJOsV2GRj2j10JLfjuA4aYkcKCNIEqRGCyTife9R8/g=="
         },
         "node_modules/loupe": {
-            "version": "3.1.1",
-            "resolved": "https://registry.npmjs.org/loupe/-/loupe-3.1.1.tgz",
-            "integrity": "sha512-edNu/8D5MKVfGVFRhFf8aAxiTM6Wumfz5XsaatSxlD3w4R1d/WEKUTydCdPGbl9K7QG/Ca3GnDV2sIKIpXRQcw==",
-            "dev": true,
-            "dependencies": {
-                "get-func-name": "^2.0.1"
-            }
+            "version": "3.1.2",
+            "resolved": "https://registry.npmjs.org/loupe/-/loupe-3.1.2.tgz",
+            "integrity": "sha512-23I4pFZHmAemUnz8WZXbYRSKYj801VDaNv9ETuMh7IrMc7VuVVSo+Z9iLE3ni30+U48iDWfi30d3twAXBYmnCg==",
+            "dev": true
         },
         "node_modules/lru-cache": {
             "version": "7.18.3",
@@ -4521,18 +4528,18 @@
             }
         },
         "node_modules/magic-string": {
-            "version": "0.30.10",
-            "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.10.tgz",
-            "integrity": "sha512-iIRwTIf0QKV3UAnYK4PU8uiEc4SRh5jX0mwpIwETPpHdhVM4f53RSwS/vXvN1JhGX+Cs7B8qIq3d6AH49O5fAQ==",
+            "version": "0.30.12",
+            "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.12.tgz",
+            "integrity": "sha512-Ea8I3sQMVXr8JhN4z+H/d8zwo+tYDgHE9+5G4Wnrwhs0gaK9fXTKx0Tw5Xwsd/bCPTTZNRAdpyzvoeORe9LYpw==",
             "dev": true,
             "dependencies": {
-                "@jridgewell/sourcemap-codec": "^1.4.15"
+                "@jridgewell/sourcemap-codec": "^1.5.0"
             }
         },
         "node_modules/memfs": {
-            "version": "4.11.1",
-            "resolved": "https://registry.npmjs.org/memfs/-/memfs-4.11.1.tgz",
-            "integrity": "sha512-LZcMTBAgqUUKNXZagcZxvXXfgF1bHX7Y7nQ0QyEiNbRJgE29GhgPd8Yna1VQcLlPiHt/5RFJMWYN9Uv/VPNvjQ==",
+            "version": "4.14.0",
+            "resolved": "https://registry.npmjs.org/memfs/-/memfs-4.14.0.tgz",
+            "integrity": "sha512-JUeY0F/fQZgIod31Ja1eJgiSxLn7BfQlCnqhwXFBzFHEw63OdLK7VJUJ7bnzNsWgCyoUP5tEp1VRY8rDaYzqOA==",
             "dev": true,
             "dependencies": {
                 "@jsonjoy.com/json-pack": "^1.0.3",
@@ -4547,12 +4554,6 @@
                 "type": "github",
                 "url": "https://github.com/sponsors/streamich"
             }
-        },
-        "node_modules/merge-stream": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
-            "integrity": "sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==",
-            "dev": true
         },
         "node_modules/merge2": {
             "version": "1.4.1",
@@ -4595,18 +4596,6 @@
                 "node": ">= 0.6"
             }
         },
-        "node_modules/mimic-fn": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-4.0.0.tgz",
-            "integrity": "sha512-vqiC06CuhBTUdZH+RYl8sFrL096vA45Ok5ISO6sE/Mr1jRbGH4Csnhi8f3wKVl7x8mO4Au7Ir9D3Oyv1VYMFJw==",
-            "dev": true,
-            "engines": {
-                "node": ">=12"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
         "node_modules/minimatch": {
             "version": "9.0.5",
             "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
@@ -4637,9 +4626,9 @@
             "peer": true
         },
         "node_modules/ms": {
-            "version": "2.1.2",
-            "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-            "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+            "version": "2.1.3",
+            "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+            "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
         },
         "node_modules/nanoid": {
             "version": "3.3.7",
@@ -4716,33 +4705,6 @@
                 "node": ">=0.10.0"
             }
         },
-        "node_modules/npm-run-path": {
-            "version": "5.3.0",
-            "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-5.3.0.tgz",
-            "integrity": "sha512-ppwTtiJZq0O/ai0z7yfudtBpWIoxM8yE6nHi1X47eFR2EWORqfbu6CnPlNsjeN683eT0qG6H/Pyf9fCcvjnnnQ==",
-            "dev": true,
-            "dependencies": {
-                "path-key": "^4.0.0"
-            },
-            "engines": {
-                "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
-        "node_modules/npm-run-path/node_modules/path-key": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/path-key/-/path-key-4.0.0.tgz",
-            "integrity": "sha512-haREypq7xkM7ErfgIyA0z+Bj4AGKlMSdlQE2jvJo6huWD1EdkKYV+G/T4nq0YEF2vgTT8kqMFKo1uHn950r4SQ==",
-            "dev": true,
-            "engines": {
-                "node": ">=12"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
         "node_modules/nth-check": {
             "version": "2.1.1",
             "resolved": "https://registry.npmjs.org/nth-check/-/nth-check-2.1.1.tgz",
@@ -4762,32 +4724,18 @@
                 "wrappy": "1"
             }
         },
-        "node_modules/onetime": {
-            "version": "6.0.0",
-            "resolved": "https://registry.npmjs.org/onetime/-/onetime-6.0.0.tgz",
-            "integrity": "sha512-1FlR+gjXK7X+AsAHso35MnyN5KqGwJRi/31ft6x0M194ht7S+rWAvd7PHss9xSKMzE0asv1pyIHaJYq+BbacAQ==",
-            "dev": true,
-            "dependencies": {
-                "mimic-fn": "^4.0.0"
-            },
-            "engines": {
-                "node": ">=12"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
         "node_modules/open": {
-            "version": "8.4.2",
-            "resolved": "https://registry.npmjs.org/open/-/open-8.4.2.tgz",
-            "integrity": "sha512-7x81NCL719oNbsq/3mh+hVrAWmFuEYUqrq/Iw3kUzH8ReypT9QQ0BLoJS7/G9k6N81XjW4qHWtjWwe/9eLy1EQ==",
+            "version": "10.1.0",
+            "resolved": "https://registry.npmjs.org/open/-/open-10.1.0.tgz",
+            "integrity": "sha512-mnkeQ1qP5Ue2wd+aivTD3NHd/lZ96Lu0jgf0pwktLPtx6cTZiH7tyeGRRHs0zX0rbrahXPnXlUnbeXyaBBuIaw==",
             "dependencies": {
-                "define-lazy-prop": "^2.0.0",
-                "is-docker": "^2.1.1",
-                "is-wsl": "^2.2.0"
+                "default-browser": "^5.2.1",
+                "define-lazy-prop": "^3.0.0",
+                "is-inside-container": "^1.0.0",
+                "is-wsl": "^3.1.0"
             },
             "engines": {
-                "node": ">=12"
+                "node": ">=18"
             },
             "funding": {
                 "url": "https://github.com/sponsors/sindresorhus"
@@ -4984,9 +4932,9 @@
             "integrity": "sha512-F3asv42UuXchdzt+xXqfW1OGlVBe+mxa2mqI0pg5yAHZPvFmY3Y6drSf/GQ1A86WgWEN9Kzh/WrgKa6iGcHXLg=="
         },
         "node_modules/picocolors": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.0.1.tgz",
-            "integrity": "sha512-anP1Z8qwhkbmu7MFP5iTt+wQKXgwzf7zTyGlcdzabySa9vd0Xt392U0rVmz9poOaBj0uHJKyyo9/upk0HrEQew==",
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+            "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
             "dev": true
         },
         "node_modules/picomatch": {
@@ -5002,9 +4950,9 @@
             }
         },
         "node_modules/postcss": {
-            "version": "8.4.45",
-            "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.45.tgz",
-            "integrity": "sha512-7KTLTdzdZZYscUc65XmjFiB73vBhBfbPztCYdUNvlaso9PrzjzcmjqBPR0lNGkcVlcO4BjiO5rK/qNz+XAen1Q==",
+            "version": "8.4.49",
+            "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.49.tgz",
+            "integrity": "sha512-OCVPnIObs4N29kxTjzLfUryOkvZEq+pf8jTF0lg8E7uETuWHA+v7j3c/xJmiqpX450191LlmZfUKkXxkTry7nA==",
             "dev": true,
             "funding": [
                 {
@@ -5022,8 +4970,8 @@
             ],
             "dependencies": {
                 "nanoid": "^3.3.7",
-                "picocolors": "^1.0.1",
-                "source-map-js": "^1.2.0"
+                "picocolors": "^1.1.1",
+                "source-map-js": "^1.2.1"
             },
             "engines": {
                 "node": "^10 || ^12 || >=14"
@@ -5344,6 +5292,17 @@
                 "@rollup/rollup-win32-ia32-msvc": "4.26.0",
                 "@rollup/rollup-win32-x64-msvc": "4.26.0",
                 "fsevents": "~2.3.2"
+            }
+        },
+        "node_modules/run-applescript": {
+            "version": "7.0.0",
+            "resolved": "https://registry.npmjs.org/run-applescript/-/run-applescript-7.0.0.tgz",
+            "integrity": "sha512-9by4Ij99JUr/MCFBUkDKLWK3G9HVXmabKz9U5MlIAIuvuzkiOicRYs8XJLxX+xahD+mLiiCYDqF9dKAgtzKP1A==",
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
             }
         },
         "node_modules/run-parallel": {
@@ -5726,18 +5685,6 @@
                 "node": ">=8"
             }
         },
-        "node_modules/strip-final-newline": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-3.0.0.tgz",
-            "integrity": "sha512-dOESqjYr96iWYylGObzd39EuNTa5VJxyvVAEm5Jnh7KGo75V43Hk1odPQkNDyXNmUR6k+gEiDVXnjB8HJ3crXw==",
-            "dev": true,
-            "engines": {
-                "node": ">=12"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
         "node_modules/strip-json-comments": {
             "version": "3.1.1",
             "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
@@ -5823,15 +5770,21 @@
             "integrity": "sha512-w89qg7PI8wAdvX60bMDP+bFoD5Dvhm9oLheFp5O4a2QF0cSBGsBX4qZmadPMvVqlLJBBci+WqGGOAPvcDeNSVg=="
         },
         "node_modules/tinybench": {
-            "version": "2.8.0",
-            "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.8.0.tgz",
-            "integrity": "sha512-1/eK7zUnIklz4JUUlL+658n58XO2hHLQfSk1Zf2LKieUjxidN16eKFEoDEfjHc3ohofSSqK3X5yO6VGb6iW8Lw==",
+            "version": "2.9.0",
+            "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+            "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+            "dev": true
+        },
+        "node_modules/tinyexec": {
+            "version": "0.3.1",
+            "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-0.3.1.tgz",
+            "integrity": "sha512-WiCJLEECkO18gwqIp6+hJg0//p23HXp4S+gGtAKu3mI2F2/sXC4FvHvXvB0zJVVaTPhx1/tOwdbRsa1sOBIKqQ==",
             "dev": true
         },
         "node_modules/tinypool": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/tinypool/-/tinypool-1.0.0.tgz",
-            "integrity": "sha512-KIKExllK7jp3uvrNtvRBYBWBOAXSX8ZvoaD8T+7KB/QHIuoJW3Pmr60zucywjAlMb5TeXUkcs/MWeWLu0qvuAQ==",
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/tinypool/-/tinypool-1.0.1.tgz",
+            "integrity": "sha512-URZYihUbRPcGv95En+sz6MfghfIc2OJ1sv/RmhWZLouPY0/8Vo80viwPvg3dlaS9fuq7fQMEfgRRK7BBZThBEA==",
             "dev": true,
             "engines": {
                 "node": "^18.0.0 || >=20.0.0"
@@ -5847,9 +5800,9 @@
             }
         },
         "node_modules/tinyspy": {
-            "version": "3.0.1",
-            "resolved": "https://registry.npmjs.org/tinyspy/-/tinyspy-3.0.1.tgz",
-            "integrity": "sha512-Zl/ko7fioZvaflejqwgnWwnTjr3K562tmyNFZADyRWYLXxkr2g+cuZ+lP+s2GRUV0PVCqqoDu0Rmx4fzdJnrZw==",
+            "version": "3.0.2",
+            "resolved": "https://registry.npmjs.org/tinyspy/-/tinyspy-3.0.2.tgz",
+            "integrity": "sha512-n1cw8k1k0x4pgA2+9XrOkFydTerNcJ1zWCO5Nn9scWHTD+5tp8dghT2x1uduQePZTZgd3Tupf+x9BxJjeJi77Q==",
             "dev": true,
             "engines": {
                 "node": ">=14.0.0"
@@ -5884,9 +5837,9 @@
             }
         },
         "node_modules/ts-api-utils": {
-            "version": "1.3.0",
-            "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-1.3.0.tgz",
-            "integrity": "sha512-UQMIo7pb8WRomKR1/+MFVLTroIvDVtMX3K6OUir8ynLyzB8Jeriont2bTAtmNPa1ekAgN7YPDyf6V+ygrdU+eQ==",
+            "version": "1.4.0",
+            "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-1.4.0.tgz",
+            "integrity": "sha512-032cPxaEKwM+GT3vA5JXNzIaizx388rhsSW79vGRNGXfRRAdEAn2mvk36PvK5HnOchyWZ7afLEXqYCvPCrzuzQ==",
             "dev": true,
             "engines": {
                 "node": ">=16"
@@ -5924,9 +5877,9 @@
             }
         },
         "node_modules/typescript": {
-            "version": "5.5.4",
-            "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.5.4.tgz",
-            "integrity": "sha512-Mtq29sKDAEYP7aljRgtPOpTvOfbwRWlS6dPRzwjdE+C0R4brX/GUyhHSecbHMFLNBLcJIPt9nl9yG5TZ1weH+Q==",
+            "version": "5.6.3",
+            "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.6.3.tgz",
+            "integrity": "sha512-hjcS1mhfuyi4WW8IWtjP7brDrG2cuDZukyrYrSauoXGNgx0S7zceP07adYkJycEr56BOUTNPzbInooiN3fn1qw==",
             "dev": true,
             "bin": {
                 "tsc": "bin/tsc",
@@ -5937,14 +5890,14 @@
             }
         },
         "node_modules/typescript-eslint": {
-            "version": "8.4.0",
-            "resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.4.0.tgz",
-            "integrity": "sha512-67qoc3zQZe3CAkO0ua17+7aCLI0dU+sSQd1eKPGq06QE4rfQjstVXR6woHO5qQvGUa550NfGckT4tzh3b3c8Pw==",
+            "version": "8.14.0",
+            "resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.14.0.tgz",
+            "integrity": "sha512-K8fBJHxVL3kxMmwByvz8hNdBJ8a0YqKzKDX6jRlrjMuNXyd5T2V02HIq37+OiWXvUUOXgOOGiSSOh26Mh8pC3w==",
             "dev": true,
             "dependencies": {
-                "@typescript-eslint/eslint-plugin": "8.4.0",
-                "@typescript-eslint/parser": "8.4.0",
-                "@typescript-eslint/utils": "8.4.0"
+                "@typescript-eslint/eslint-plugin": "8.14.0",
+                "@typescript-eslint/parser": "8.14.0",
+                "@typescript-eslint/utils": "8.14.0"
             },
             "engines": {
                 "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -6076,15 +6029,14 @@
             }
         },
         "node_modules/vite-node": {
-            "version": "2.0.5",
-            "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-2.0.5.tgz",
-            "integrity": "sha512-LdsW4pxj0Ot69FAoXZ1yTnA9bjGohr2yNBU7QKRxpz8ITSkhuDl6h3zS/tvgz4qrNjeRnvrWeXQ8ZF7Um4W00Q==",
+            "version": "2.1.4",
+            "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-2.1.4.tgz",
+            "integrity": "sha512-kqa9v+oi4HwkG6g8ufRnb5AeplcRw8jUF6/7/Qz1qRQOXHImG8YnLbB+LLszENwFnoBl9xIf9nVdCFzNd7GQEg==",
             "dev": true,
             "dependencies": {
                 "cac": "^6.7.14",
-                "debug": "^4.3.5",
+                "debug": "^4.3.7",
                 "pathe": "^1.1.2",
-                "tinyrainbow": "^1.2.0",
                 "vite": "^5.0.0"
             },
             "bin": {
@@ -6098,29 +6050,30 @@
             }
         },
         "node_modules/vitest": {
-            "version": "2.0.5",
-            "resolved": "https://registry.npmjs.org/vitest/-/vitest-2.0.5.tgz",
-            "integrity": "sha512-8GUxONfauuIdeSl5f9GTgVEpg5BTOlplET4WEDaeY2QBiN8wSm68vxN/tb5z405OwppfoCavnwXafiaYBC/xOA==",
+            "version": "2.1.4",
+            "resolved": "https://registry.npmjs.org/vitest/-/vitest-2.1.4.tgz",
+            "integrity": "sha512-eDjxbVAJw1UJJCHr5xr/xM86Zx+YxIEXGAR+bmnEID7z9qWfoxpHw0zdobz+TQAFOLT+nEXz3+gx6nUJ7RgmlQ==",
             "dev": true,
             "dependencies": {
-                "@ampproject/remapping": "^2.3.0",
-                "@vitest/expect": "2.0.5",
-                "@vitest/pretty-format": "^2.0.5",
-                "@vitest/runner": "2.0.5",
-                "@vitest/snapshot": "2.0.5",
-                "@vitest/spy": "2.0.5",
-                "@vitest/utils": "2.0.5",
-                "chai": "^5.1.1",
-                "debug": "^4.3.5",
-                "execa": "^8.0.1",
-                "magic-string": "^0.30.10",
+                "@vitest/expect": "2.1.4",
+                "@vitest/mocker": "2.1.4",
+                "@vitest/pretty-format": "^2.1.4",
+                "@vitest/runner": "2.1.4",
+                "@vitest/snapshot": "2.1.4",
+                "@vitest/spy": "2.1.4",
+                "@vitest/utils": "2.1.4",
+                "chai": "^5.1.2",
+                "debug": "^4.3.7",
+                "expect-type": "^1.1.0",
+                "magic-string": "^0.30.12",
                 "pathe": "^1.1.2",
                 "std-env": "^3.7.0",
-                "tinybench": "^2.8.0",
-                "tinypool": "^1.0.0",
+                "tinybench": "^2.9.0",
+                "tinyexec": "^0.3.1",
+                "tinypool": "^1.0.1",
                 "tinyrainbow": "^1.2.0",
                 "vite": "^5.0.0",
-                "vite-node": "2.0.5",
+                "vite-node": "2.1.4",
                 "why-is-node-running": "^2.3.0"
             },
             "bin": {
@@ -6135,8 +6088,8 @@
             "peerDependencies": {
                 "@edge-runtime/vm": "*",
                 "@types/node": "^18.0.0 || >=20.0.0",
-                "@vitest/browser": "2.0.5",
-                "@vitest/ui": "2.0.5",
+                "@vitest/browser": "2.1.4",
+                "@vitest/ui": "2.1.4",
                 "happy-dom": "*",
                 "jsdom": "*"
             },

--- a/package-lock.json
+++ b/package-lock.json
@@ -1019,9 +1019,9 @@
             }
         },
         "node_modules/@rollup/rollup-android-arm-eabi": {
-            "version": "4.21.2",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.21.2.tgz",
-            "integrity": "sha512-fSuPrt0ZO8uXeS+xP3b+yYTCBUd05MoSp2N/MFOgjhhUhMmchXlpTQrTpI8T+YAwAQuK7MafsCOxW7VrPMrJcg==",
+            "version": "4.26.0",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.26.0.tgz",
+            "integrity": "sha512-gJNwtPDGEaOEgejbaseY6xMFu+CPltsc8/T+diUTTbOQLqD+bnrJq9ulH6WD69TqwqWmrfRAtUv30cCFZlbGTQ==",
             "cpu": [
                 "arm"
             ],
@@ -1032,9 +1032,9 @@
             ]
         },
         "node_modules/@rollup/rollup-android-arm64": {
-            "version": "4.21.2",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.21.2.tgz",
-            "integrity": "sha512-xGU5ZQmPlsjQS6tzTTGwMsnKUtu0WVbl0hYpTPauvbRAnmIvpInhJtgjj3mcuJpEiuUw4v1s4BimkdfDWlh7gA==",
+            "version": "4.26.0",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.26.0.tgz",
+            "integrity": "sha512-YJa5Gy8mEZgz5JquFruhJODMq3lTHWLm1fOy+HIANquLzfIOzE9RA5ie3JjCdVb9r46qfAQY/l947V0zfGJ0OQ==",
             "cpu": [
                 "arm64"
             ],
@@ -1045,9 +1045,9 @@
             ]
         },
         "node_modules/@rollup/rollup-darwin-arm64": {
-            "version": "4.21.2",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.21.2.tgz",
-            "integrity": "sha512-99AhQ3/ZMxU7jw34Sq8brzXqWH/bMnf7ZVhvLk9QU2cOepbQSVTns6qoErJmSiAvU3InRqC2RRZ5ovh1KN0d0Q==",
+            "version": "4.26.0",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.26.0.tgz",
+            "integrity": "sha512-ErTASs8YKbqTBoPLp/kA1B1Um5YSom8QAc4rKhg7b9tyyVqDBlQxy7Bf2wW7yIlPGPg2UODDQcbkTlruPzDosw==",
             "cpu": [
                 "arm64"
             ],
@@ -1058,9 +1058,9 @@
             ]
         },
         "node_modules/@rollup/rollup-darwin-x64": {
-            "version": "4.21.2",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.21.2.tgz",
-            "integrity": "sha512-ZbRaUvw2iN/y37x6dY50D8m2BnDbBjlnMPotDi/qITMJ4sIxNY33HArjikDyakhSv0+ybdUxhWxE6kTI4oX26w==",
+            "version": "4.26.0",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.26.0.tgz",
+            "integrity": "sha512-wbgkYDHcdWW+NqP2mnf2NOuEbOLzDblalrOWcPyY6+BRbVhliavon15UploG7PpBRQ2bZJnbmh8o3yLoBvDIHA==",
             "cpu": [
                 "x64"
             ],
@@ -1070,10 +1070,36 @@
                 "darwin"
             ]
         },
+        "node_modules/@rollup/rollup-freebsd-arm64": {
+            "version": "4.26.0",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.26.0.tgz",
+            "integrity": "sha512-Y9vpjfp9CDkAG4q/uwuhZk96LP11fBz/bYdyg9oaHYhtGZp7NrbkQrj/66DYMMP2Yo/QPAsVHkV891KyO52fhg==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "optional": true,
+            "os": [
+                "freebsd"
+            ]
+        },
+        "node_modules/@rollup/rollup-freebsd-x64": {
+            "version": "4.26.0",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.26.0.tgz",
+            "integrity": "sha512-A/jvfCZ55EYPsqeaAt/yDAG4q5tt1ZboWMHEvKAH9Zl92DWvMIbnZe/f/eOXze65aJaaKbL+YeM0Hz4kLQvdwg==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "optional": true,
+            "os": [
+                "freebsd"
+            ]
+        },
         "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
-            "version": "4.21.2",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.21.2.tgz",
-            "integrity": "sha512-ztRJJMiE8nnU1YFcdbd9BcH6bGWG1z+jP+IPW2oDUAPxPjo9dverIOyXz76m6IPA6udEL12reYeLojzW2cYL7w==",
+            "version": "4.26.0",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.26.0.tgz",
+            "integrity": "sha512-paHF1bMXKDuizaMODm2bBTjRiHxESWiIyIdMugKeLnjuS1TCS54MF5+Y5Dx8Ui/1RBPVRE09i5OUlaLnv8OGnA==",
             "cpu": [
                 "arm"
             ],
@@ -1084,9 +1110,9 @@
             ]
         },
         "node_modules/@rollup/rollup-linux-arm-musleabihf": {
-            "version": "4.21.2",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.21.2.tgz",
-            "integrity": "sha512-flOcGHDZajGKYpLV0JNc0VFH361M7rnV1ee+NTeC/BQQ1/0pllYcFmxpagltANYt8FYf9+kL6RSk80Ziwyhr7w==",
+            "version": "4.26.0",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.26.0.tgz",
+            "integrity": "sha512-cwxiHZU1GAs+TMxvgPfUDtVZjdBdTsQwVnNlzRXC5QzIJ6nhfB4I1ahKoe9yPmoaA/Vhf7m9dB1chGPpDRdGXg==",
             "cpu": [
                 "arm"
             ],
@@ -1097,9 +1123,9 @@
             ]
         },
         "node_modules/@rollup/rollup-linux-arm64-gnu": {
-            "version": "4.21.2",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.21.2.tgz",
-            "integrity": "sha512-69CF19Kp3TdMopyteO/LJbWufOzqqXzkrv4L2sP8kfMaAQ6iwky7NoXTp7bD6/irKgknDKM0P9E/1l5XxVQAhw==",
+            "version": "4.26.0",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.26.0.tgz",
+            "integrity": "sha512-4daeEUQutGRCW/9zEo8JtdAgtJ1q2g5oHaoQaZbMSKaIWKDQwQ3Yx0/3jJNmpzrsScIPtx/V+1AfibLisb3AMQ==",
             "cpu": [
                 "arm64"
             ],
@@ -1110,9 +1136,9 @@
             ]
         },
         "node_modules/@rollup/rollup-linux-arm64-musl": {
-            "version": "4.21.2",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.21.2.tgz",
-            "integrity": "sha512-48pD/fJkTiHAZTnZwR0VzHrao70/4MlzJrq0ZsILjLW/Ab/1XlVUStYyGt7tdyIiVSlGZbnliqmult/QGA2O2w==",
+            "version": "4.26.0",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.26.0.tgz",
+            "integrity": "sha512-eGkX7zzkNxvvS05ROzJ/cO/AKqNvR/7t1jA3VZDi2vRniLKwAWxUr85fH3NsvtxU5vnUUKFHKh8flIBdlo2b3Q==",
             "cpu": [
                 "arm64"
             ],
@@ -1123,9 +1149,9 @@
             ]
         },
         "node_modules/@rollup/rollup-linux-powerpc64le-gnu": {
-            "version": "4.21.2",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-powerpc64le-gnu/-/rollup-linux-powerpc64le-gnu-4.21.2.tgz",
-            "integrity": "sha512-cZdyuInj0ofc7mAQpKcPR2a2iu4YM4FQfuUzCVA2u4HI95lCwzjoPtdWjdpDKyHxI0UO82bLDoOaLfpZ/wviyQ==",
+            "version": "4.26.0",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-powerpc64le-gnu/-/rollup-linux-powerpc64le-gnu-4.26.0.tgz",
+            "integrity": "sha512-Odp/lgHbW/mAqw/pU21goo5ruWsytP7/HCC/liOt0zcGG0llYWKrd10k9Fj0pdj3prQ63N5yQLCLiE7HTX+MYw==",
             "cpu": [
                 "ppc64"
             ],
@@ -1136,9 +1162,9 @@
             ]
         },
         "node_modules/@rollup/rollup-linux-riscv64-gnu": {
-            "version": "4.21.2",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.21.2.tgz",
-            "integrity": "sha512-RL56JMT6NwQ0lXIQmMIWr1SW28z4E4pOhRRNqwWZeXpRlykRIlEpSWdsgNWJbYBEWD84eocjSGDu/XxbYeCmwg==",
+            "version": "4.26.0",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.26.0.tgz",
+            "integrity": "sha512-MBR2ZhCTzUgVD0OJdTzNeF4+zsVogIR1U/FsyuFerwcqjZGvg2nYe24SAHp8O5sN8ZkRVbHwlYeHqcSQ8tcYew==",
             "cpu": [
                 "riscv64"
             ],
@@ -1149,9 +1175,9 @@
             ]
         },
         "node_modules/@rollup/rollup-linux-s390x-gnu": {
-            "version": "4.21.2",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.21.2.tgz",
-            "integrity": "sha512-PMxkrWS9z38bCr3rWvDFVGD6sFeZJw4iQlhrup7ReGmfn7Oukrr/zweLhYX6v2/8J6Cep9IEA/SmjXjCmSbrMQ==",
+            "version": "4.26.0",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.26.0.tgz",
+            "integrity": "sha512-YYcg8MkbN17fMbRMZuxwmxWqsmQufh3ZJFxFGoHjrE7bv0X+T6l3glcdzd7IKLiwhT+PZOJCblpnNlz1/C3kGQ==",
             "cpu": [
                 "s390x"
             ],
@@ -1162,9 +1188,9 @@
             ]
         },
         "node_modules/@rollup/rollup-linux-x64-gnu": {
-            "version": "4.21.2",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.21.2.tgz",
-            "integrity": "sha512-B90tYAUoLhU22olrafY3JQCFLnT3NglazdwkHyxNDYF/zAxJt5fJUB/yBoWFoIQ7SQj+KLe3iL4BhOMa9fzgpw==",
+            "version": "4.26.0",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.26.0.tgz",
+            "integrity": "sha512-ZuwpfjCwjPkAOxpjAEjabg6LRSfL7cAJb6gSQGZYjGhadlzKKywDkCUnJ+KEfrNY1jH5EEoSIKLCb572jSiglA==",
             "cpu": [
                 "x64"
             ],
@@ -1175,9 +1201,9 @@
             ]
         },
         "node_modules/@rollup/rollup-linux-x64-musl": {
-            "version": "4.21.2",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.21.2.tgz",
-            "integrity": "sha512-7twFizNXudESmC9oneLGIUmoHiiLppz/Xs5uJQ4ShvE6234K0VB1/aJYU3f/4g7PhssLGKBVCC37uRkkOi8wjg==",
+            "version": "4.26.0",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.26.0.tgz",
+            "integrity": "sha512-+HJD2lFS86qkeF8kNu0kALtifMpPCZU80HvwztIKnYwym3KnA1os6nsX4BGSTLtS2QVAGG1P3guRgsYyMA0Yhg==",
             "cpu": [
                 "x64"
             ],
@@ -1188,9 +1214,9 @@
             ]
         },
         "node_modules/@rollup/rollup-win32-arm64-msvc": {
-            "version": "4.21.2",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.21.2.tgz",
-            "integrity": "sha512-9rRero0E7qTeYf6+rFh3AErTNU1VCQg2mn7CQcI44vNUWM9Ze7MSRS/9RFuSsox+vstRt97+x3sOhEey024FRQ==",
+            "version": "4.26.0",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.26.0.tgz",
+            "integrity": "sha512-WUQzVFWPSw2uJzX4j6YEbMAiLbs0BUysgysh8s817doAYhR5ybqTI1wtKARQKo6cGop3pHnrUJPFCsXdoFaimQ==",
             "cpu": [
                 "arm64"
             ],
@@ -1201,9 +1227,9 @@
             ]
         },
         "node_modules/@rollup/rollup-win32-ia32-msvc": {
-            "version": "4.21.2",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.21.2.tgz",
-            "integrity": "sha512-5rA4vjlqgrpbFVVHX3qkrCo/fZTj1q0Xxpg+Z7yIo3J2AilW7t2+n6Q8Jrx+4MrYpAnjttTYF8rr7bP46BPzRw==",
+            "version": "4.26.0",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.26.0.tgz",
+            "integrity": "sha512-D4CxkazFKBfN1akAIY6ieyOqzoOoBV1OICxgUblWxff/pSjCA2khXlASUx7mK6W1oP4McqhgcCsu6QaLj3WMWg==",
             "cpu": [
                 "ia32"
             ],
@@ -1214,9 +1240,9 @@
             ]
         },
         "node_modules/@rollup/rollup-win32-x64-msvc": {
-            "version": "4.21.2",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.21.2.tgz",
-            "integrity": "sha512-6UUxd0+SKomjdzuAcp+HAmxw1FlGBnl1v2yEPSabtx4lBfdXHDVsW7+lQkgz9cNFJGY3AWR7+V8P5BqkD9L9nA==",
+            "version": "4.26.0",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.26.0.tgz",
+            "integrity": "sha512-2x8MO1rm4PGEP0xWbubJW5RtbNLk3puzAMaLQd3B3JHVw4KcHlmXcO+Wewx9zCoo7EUFiMlu/aZbCJ7VjMzAag==",
             "cpu": [
                 "x64"
             ],
@@ -1239,9 +1265,9 @@
             "integrity": "sha512-C5Mc6rdnsaJDjO3UpGW/CQTHtCKaYlScZTly4JIu97Jxo/odCiH0ITnDXSJPTOrEKk/ycSZ0AOgTmkDtkOsvIA=="
         },
         "node_modules/@types/estree": {
-            "version": "1.0.5",
-            "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.5.tgz",
-            "integrity": "sha512-/kYRxGDLWzHOB7q+wtSUQlFrtcdUccpfy+X+9iMBpHK8QLLhx2wIPYuS5DYtR9Wa/YlZAbIovy7qVdB1Aq6Lyw==",
+            "version": "1.0.6",
+            "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.6.tgz",
+            "integrity": "sha512-AYnb1nQyY49te+VRAVgmzfcgjYS91mY5P0TKUDCLEM+gNnA+3T6rWITXRLYCpahpqSQbN5cE+gHpnPyXjHWxcw==",
             "dev": true
         },
         "node_modules/@types/istanbul-lib-coverage": {
@@ -5284,12 +5310,12 @@
             "integrity": "sha512-22MOP1Rh7sAo1BZpDG6R5RFYzR2lYEgwq7HEmyW2qcsOqR2lQKmn+O//xV3YG/0rrhMC6KVX2hU+ZXuaw9a5bw=="
         },
         "node_modules/rollup": {
-            "version": "4.21.2",
-            "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.21.2.tgz",
-            "integrity": "sha512-e3TapAgYf9xjdLvKQCkQTnbTKd4a6jwlpQSJJFokHGaX2IVjoEqkIIhiQfqsi0cdwlOD+tQGuOd5AJkc5RngBw==",
+            "version": "4.26.0",
+            "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.26.0.tgz",
+            "integrity": "sha512-ilcl12hnWonG8f+NxU6BlgysVA0gvY2l8N0R84S1HcINbW20bvwuCngJkkInV6LXhwRpucsW5k1ovDwEdBVrNg==",
             "dev": true,
             "dependencies": {
-                "@types/estree": "1.0.5"
+                "@types/estree": "1.0.6"
             },
             "bin": {
                 "rollup": "dist/bin/rollup"
@@ -5299,22 +5325,24 @@
                 "npm": ">=8.0.0"
             },
             "optionalDependencies": {
-                "@rollup/rollup-android-arm-eabi": "4.21.2",
-                "@rollup/rollup-android-arm64": "4.21.2",
-                "@rollup/rollup-darwin-arm64": "4.21.2",
-                "@rollup/rollup-darwin-x64": "4.21.2",
-                "@rollup/rollup-linux-arm-gnueabihf": "4.21.2",
-                "@rollup/rollup-linux-arm-musleabihf": "4.21.2",
-                "@rollup/rollup-linux-arm64-gnu": "4.21.2",
-                "@rollup/rollup-linux-arm64-musl": "4.21.2",
-                "@rollup/rollup-linux-powerpc64le-gnu": "4.21.2",
-                "@rollup/rollup-linux-riscv64-gnu": "4.21.2",
-                "@rollup/rollup-linux-s390x-gnu": "4.21.2",
-                "@rollup/rollup-linux-x64-gnu": "4.21.2",
-                "@rollup/rollup-linux-x64-musl": "4.21.2",
-                "@rollup/rollup-win32-arm64-msvc": "4.21.2",
-                "@rollup/rollup-win32-ia32-msvc": "4.21.2",
-                "@rollup/rollup-win32-x64-msvc": "4.21.2",
+                "@rollup/rollup-android-arm-eabi": "4.26.0",
+                "@rollup/rollup-android-arm64": "4.26.0",
+                "@rollup/rollup-darwin-arm64": "4.26.0",
+                "@rollup/rollup-darwin-x64": "4.26.0",
+                "@rollup/rollup-freebsd-arm64": "4.26.0",
+                "@rollup/rollup-freebsd-x64": "4.26.0",
+                "@rollup/rollup-linux-arm-gnueabihf": "4.26.0",
+                "@rollup/rollup-linux-arm-musleabihf": "4.26.0",
+                "@rollup/rollup-linux-arm64-gnu": "4.26.0",
+                "@rollup/rollup-linux-arm64-musl": "4.26.0",
+                "@rollup/rollup-linux-powerpc64le-gnu": "4.26.0",
+                "@rollup/rollup-linux-riscv64-gnu": "4.26.0",
+                "@rollup/rollup-linux-s390x-gnu": "4.26.0",
+                "@rollup/rollup-linux-x64-gnu": "4.26.0",
+                "@rollup/rollup-linux-x64-musl": "4.26.0",
+                "@rollup/rollup-win32-arm64-msvc": "4.26.0",
+                "@rollup/rollup-win32-ia32-msvc": "4.26.0",
+                "@rollup/rollup-win32-x64-msvc": "4.26.0",
                 "fsevents": "~2.3.2"
             }
         },
@@ -5989,9 +6017,9 @@
             "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw=="
         },
         "node_modules/vite": {
-            "version": "5.4.3",
-            "resolved": "https://registry.npmjs.org/vite/-/vite-5.4.3.tgz",
-            "integrity": "sha512-IH+nl64eq9lJjFqU+/yrRnrHPVTlgy42/+IzbOdaFDVlyLgI/wDlf+FCobXLX1cT0X5+7LMyH1mIy2xJdLfo8Q==",
+            "version": "5.4.11",
+            "resolved": "https://registry.npmjs.org/vite/-/vite-5.4.11.tgz",
+            "integrity": "sha512-c7jFQRklXua0mTzneGW9QVyxFjUgwcihC4bXEtujIo2ouWCe1Ajt/amn2PCxYnhYfd5k09JX3SB7OYWFKYqj8Q==",
             "dev": true,
             "dependencies": {
                 "esbuild": "^0.21.3",

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "dependencies": {
         "@wdio/logger": "^8.0.0 || ^9.0.0",
         "axios": "^1.0.0",
-        "open": "^8.0.0",
+        "open": "^10.0.0",
         "sax": "^1.0.0",
         "webdriver": "^8.0.0 || ^9.0.0",
         "yaml": "^2.0.0"
@@ -48,19 +48,19 @@
         "webdriverio": "^8.0.0 || ^9.0.0"
     },
     "devDependencies": {
-        "@eslint/js": "^9.6.0",
+        "@eslint/js": "^9.14.0",
         "@types/node": "^18.0.0",
         "@types/sax": "^1.2.7",
         "@wdio/globals": "^8.0.0 || ^9.0.0",
         "@wdio/protocols": "^8.0.0 || ^9.0.0",
         "@wdio/types": "^8.0.0 || ^9.0.0",
-        "eslint": "^9.9.0",
+        "eslint": "^9.14.0",
         "eslint-config-prettier": "^9.1.0",
-        "memfs": "^4.11.1",
+        "memfs": "^4.14.0",
         "prettier": "^3.3.3",
-        "typescript": "^5.5.4",
-        "typescript-eslint": "^8.4.0",
-        "vitest": "^2.0.5"
+        "typescript": "^5.6.3",
+        "typescript-eslint": "^8.14.0",
+        "vitest": "^2.1.4"
     },
     "files": [
         "dist"


### PR DESCRIPTION
* Update all of our dev dependencies to avoid versions that have declared vulnerabilities.
* Bump `open` to 10.x now that the library is ESM only (Because webdriver is ESM only)