### PR TITLE
DEVOPS-843: Pin GitHub Actions to commit SHA

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -12,9 +12,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - name: Use Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: 22.x
       - name: Install packages
@@ -26,7 +26,7 @@ jobs:
       - name: Generate package
         run: npm pack
       - name: Upload artifact (Package)
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: package
           path: '*.tgz'
@@ -45,9 +45,9 @@ jobs:
         wdio-version: ['^8.0.0', '^9.0.0']
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: ${{ matrix.node-version }}
       - name: Force wdio version ${{ matrix.wdio-version }}


### PR DESCRIPTION
This PR updates GitHub Actions to use commit SHAs instead of tags or branches.

Updated files:
- .github/workflows/build.yaml